### PR TITLE
feat: on-device neural net scanner with colour detection

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,5 +1,8 @@
 # Large data files — don't commit to git
+# Reproducible: run download_images.py → train_brand_classifier.py
 images/
+images_by_brand/
+models/
 chroma_db/
 raw/
 processed/

--- a/data/download_images.py
+++ b/data/download_images.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 BASE_URL = "https://unaudinary.com"
+FIREBASE_BUCKET = "gs://recycled-sound-app.firebasestorage.app/training-data/images/"
 DATA_DIR = Path(__file__).parent
 IMAGE_DIR = DATA_DIR / "images"
 URLS_FILE = DATA_DIR / "raw" / "image_urls.json"
@@ -116,5 +117,22 @@ async def main():
     print(f"   Manifest: {manifest_path} ({len(manifest)} entries)")
 
 
+def restore_from_firebase():
+    """Restore training images from Firebase Storage backup.
+
+    Use this if unaudinary.com is down. Requires gsutil and GCP auth.
+    Usage: python3 download_images.py --from-firebase
+    """
+    print(f"🔥 Restoring from Firebase Storage...")
+    print(f"   Source: {FIREBASE_BUCKET}")
+    print(f"   Destination: {IMAGE_DIR}")
+    IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+    os.system(f"gsutil -m rsync -r {FIREBASE_BUCKET} {IMAGE_DIR}/")
+    print("✅ Done!")
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    if "--from-firebase" in sys.argv:
+        restore_from_firebase()
+    else:
+        asyncio.run(main())

--- a/data/linear_probe.py
+++ b/data/linear_probe.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+🔬 Recycled Sound — Linear Probe on Frozen CLIP Embeddings
+
+Diagnostic experiment: do CLIP's frozen ViT-B/32 features contain enough signal
+to classify hearing aids by brand, style, or battery size?
+
+Three probes on pre-computed 512-dim embeddings from device_catalog.json:
+  1. Brand classification (16 manufacturers)
+  2. Style classification (BTE/RIC/ITE/CIC/ITC/IIC)
+  3. Battery size classification (10/13/312/675/Rechargeable)
+
+Each probe: LogisticRegression on frozen features, 80/20 stratified split,
+accuracy + confusion matrix + per-class precision/recall.
+
+Usage:
+    python3 data/linear_probe.py                    # full report
+    python3 data/linear_probe.py --json             # machine-readable
+    python3 data/linear_probe.py --real /path/to/   # test real-world photos
+
+Requires: scikit-learn, numpy. Optional: open_clip, torch, PIL (for --real).
+"""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+DATA_DIR = Path(__file__).parent
+CATALOG_PATH = DATA_DIR.parent / "recycled_sound" / "assets" / "device_catalog.json"
+EMBEDDINGS_PATH = DATA_DIR / "processed" / "visual_embeddings.json"
+
+
+def load_data():
+    """Load embeddings and labels from the visual embeddings + device catalog.
+
+    Returns (embeddings, labels_dict) where labels_dict maps:
+        'brand' -> list[str]     manufacturer name per embedding
+        'style' -> list[str]     device type (BTE/RIC/ITE/CIC/ITC/IIC)
+        'battery' -> list[str]   battery size (10/13/312/675/Rechargeable)
+
+    Embeddings with ambiguous labels (multiple manufacturers) are kept and
+    labeled by majority vote. This is intentional — OEM rebrands (e.g.
+    Amplifon ≡ ReSound hardware) are real-world ambiguity the probe should
+    surface, not hide.
+    """
+    print("Loading visual embeddings...", end=" ", flush=True)
+    with open(EMBEDDINGS_PATH) as f:
+        vis_data = json.load(f)
+    print(f"{len(vis_data)} entries")
+
+    print("Loading device catalog...", end=" ", flush=True)
+    with open(CATALOG_PATH) as f:
+        catalog = json.load(f)
+    devices = catalog["devices"]
+    embedding_index = catalog["embeddingIndex"]
+    print(f"{len(devices)} devices, {len(embedding_index)} embedding mappings")
+
+    embeddings = []
+    brands = []
+    styles = []
+    batteries = []
+
+    for i, entry in enumerate(vis_data):
+        emb = entry["embedding"]
+        if len(emb) != 512:
+            continue
+
+        # Get brand from visual_embeddings (majority vote if mixed)
+        mfr_counts = Counter(d["manufacturer"] for d in entry["devices"])
+        brand = mfr_counts.most_common(1)[0][0]
+
+        # Get style and battery from device_catalog via embeddingIndex
+        style = None
+        battery = None
+        if i < len(embedding_index):
+            device_ids = embedding_index[i]["deviceIds"]
+            # Take first device that has type/battery info
+            for did in device_ids:
+                if did in devices:
+                    dev = devices[did]
+                    if not style and dev.get("type"):
+                        # Normalize: "BTE (Behind-the-Ear)" -> "BTE"
+                        style = dev["type"].split(" ")[0]
+                    if not battery and dev.get("batterySize"):
+                        bs = dev["batterySize"]
+                        # Normalize: "Size 312" -> "312"
+                        battery = bs.replace("Size ", "")
+                    if style and battery:
+                        break
+
+        embeddings.append(emb)
+        brands.append(brand)
+        styles.append(style or "unknown")
+        batteries.append(battery or "unknown")
+
+    return (
+        np.array(embeddings, dtype=np.float32),
+        {"brand": brands, "style": styles, "battery": batteries},
+    )
+
+
+def run_probe(X, y, task_name, min_samples=5):
+    """Train and evaluate a linear probe.
+
+    Args:
+        X: (N, 512) embedding matrix
+        y: list of string labels
+        task_name: name for reporting
+        min_samples: minimum samples per class to include
+
+    Returns dict with accuracy, per-class metrics, confusion matrix.
+    """
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.metrics import (
+        accuracy_score,
+        classification_report,
+        confusion_matrix,
+    )
+    from sklearn.model_selection import StratifiedKFold, cross_val_score, train_test_split
+    from sklearn.preprocessing import LabelEncoder
+
+    # Filter out unknowns and rare classes
+    label_counts = Counter(y)
+    valid_labels = {l for l, c in label_counts.items() if l != "unknown" and c >= min_samples}
+    mask = [l in valid_labels for l in y]
+    X_filtered = X[mask]
+    y_filtered = [l for l, m in zip(y, mask) if m]
+
+    n_classes = len(valid_labels)
+    n_samples = len(y_filtered)
+    print(f"\n{'='*60}")
+    print(f"PROBE: {task_name}")
+    print(f"{'='*60}")
+    print(f"Samples: {n_samples} (dropped {len(y) - n_samples} unknown/rare)")
+    print(f"Classes: {n_classes}")
+
+    # Show class distribution
+    dist = Counter(y_filtered)
+    print(f"\nClass distribution:")
+    for label, count in sorted(dist.items(), key=lambda x: -x[1]):
+        bar = "█" * (count * 40 // max(dist.values()))
+        print(f"  {label:25s} {count:4d}  {bar}")
+
+    # Encode labels
+    le = LabelEncoder()
+    y_enc = le.fit_transform(y_filtered)
+
+    # 80/20 stratified split
+    X_train, X_test, y_train, y_test = train_test_split(
+        X_filtered, y_enc, test_size=0.2, random_state=42, stratify=y_enc
+    )
+
+    # L2-normalize embeddings (CLIP outputs are already roughly normalized,
+    # but let's be explicit — this makes the linear probe equivalent to
+    # cosine-similarity-based classification)
+    from sklearn.preprocessing import normalize
+    X_train = normalize(X_train)
+    X_test = normalize(X_test)
+
+    # Train logistic regression
+    # max_iter=2000 because some convergence is slow with 16 classes
+    clf = LogisticRegression(
+        max_iter=2000,
+        C=1.0,
+        solver="lbfgs",
+        random_state=42,
+    )
+    clf.fit(X_train, y_train)
+
+    # Evaluate
+    y_pred = clf.predict(X_test)
+    accuracy = accuracy_score(y_test, y_pred)
+
+    print(f"\n>>> ACCURACY: {accuracy:.1%} <<<")
+
+    # Per-class report
+    report = classification_report(
+        y_test, y_pred, target_names=le.classes_, output_dict=True, zero_division=0
+    )
+    print(f"\nPer-class precision / recall / F1:")
+    print(f"  {'Class':25s} {'Prec':>6s} {'Recall':>6s} {'F1':>6s} {'N':>5s}")
+    print(f"  {'-'*50}")
+    for cls in le.classes_:
+        r = report[cls]
+        print(f"  {cls:25s} {r['precision']:6.1%} {r['recall']:6.1%} {r['f1-score']:6.1%} {r['support']:5.0f}")
+
+    # Confusion matrix
+    cm = confusion_matrix(y_test, y_pred)
+    print(f"\nConfusion matrix (rows=true, cols=predicted):")
+    # Header
+    header = "  " + " " * 14 + "".join(f"{c[:6]:>7s}" for c in le.classes_)
+    print(header)
+    for i, cls in enumerate(le.classes_):
+        row = f"  {cls[:13]:13s} " + "".join(
+            f"{cm[i, j]:7d}" if cm[i, j] > 0 else "      ." for j in range(len(le.classes_))
+        )
+        print(row)
+
+    # Cross-validation for robustness check
+    X_all = normalize(X_filtered)
+    cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
+    cv_scores = cross_val_score(clf, X_all, y_enc, cv=cv, scoring="accuracy")
+    print(f"\n5-fold CV: {cv_scores.mean():.1%} ± {cv_scores.std():.1%}")
+
+    # Find most-confused pairs
+    print(f"\nMost confused pairs:")
+    confused = []
+    for i in range(len(le.classes_)):
+        for j in range(len(le.classes_)):
+            if i != j and cm[i, j] > 0:
+                confused.append((cm[i, j], le.classes_[i], le.classes_[j]))
+    confused.sort(reverse=True)
+    for count, true, pred in confused[:10]:
+        print(f"  {true} → {pred}: {count} times")
+
+    return {
+        "task": task_name,
+        "accuracy": accuracy,
+        "n_samples": n_samples,
+        "n_classes": n_classes,
+        "cv_mean": cv_scores.mean(),
+        "cv_std": cv_scores.std(),
+        "report": report,
+        "confusion_matrix": cm.tolist(),
+        "class_names": le.classes_.tolist(),
+        "confused_pairs": [(c, t, p) for c, t, p in confused[:10]],
+    }
+
+
+def probe_real_photos(real_dir, catalog_devices, results):
+    """Encode real-world photos with CLIP and classify using trained probes.
+
+    This measures the domain gap: product shot accuracy vs real-world accuracy.
+    """
+    try:
+        import open_clip
+        import torch
+        from PIL import Image
+    except ImportError:
+        print("\n⚠️  Skipping real-photo test (requires open_clip, torch, PIL)")
+        return
+
+    real_path = Path(real_dir)
+    photos = list(real_path.glob("*.jpg")) + list(real_path.glob("*.png")) + list(real_path.glob("*.heic"))
+    if not photos:
+        print(f"\n⚠️  No photos found in {real_dir}")
+        return
+
+    print(f"\n{'='*60}")
+    print(f"REAL-WORLD DOMAIN GAP TEST")
+    print(f"{'='*60}")
+    print(f"Photos: {len(photos)} from {real_dir}")
+
+    # Load CLIP model (same as cloud function: ViT-B-32, laion2b_s34b_b79k)
+    print("Loading CLIP ViT-B/32...", end=" ", flush=True)
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        "ViT-B-32", pretrained="laion2b_s34b_b79k"
+    )
+    model.eval()
+    print("done")
+
+    # Encode each photo
+    for photo in sorted(photos):
+        print(f"\n  {photo.name}:")
+        try:
+            image = preprocess(Image.open(photo).convert("RGB")).unsqueeze(0)
+            with torch.no_grad():
+                emb = model.encode_image(image)
+                emb = emb / emb.norm(dim=-1, keepdim=True)
+                emb_np = emb.squeeze().numpy()
+            print(f"    Encoded: {emb_np.shape} (norm={np.linalg.norm(emb_np):.3f})")
+
+            # Classify with each trained probe
+            for result in results:
+                if "classifier" in result:
+                    from sklearn.preprocessing import normalize
+                    emb_normed = normalize(emb_np.reshape(1, -1))
+                    pred = result["classifier"].predict(emb_normed)[0]
+                    proba = result["classifier"].predict_proba(emb_normed)[0]
+                    top_idx = np.argsort(proba)[-3:][::-1]
+                    classes = result["class_names"]
+                    print(f"    {result['task']:10s}: {classes[pred]} "
+                          f"({proba[pred]:.1%})")
+                    print(f"               top-3: "
+                          + ", ".join(f"{classes[i]} ({proba[i]:.1%})" for i in top_idx))
+        except Exception as e:
+            print(f"    ERROR: {e}")
+
+
+def write_results_doc(results, output_path):
+    """Write decision gate document."""
+    with open(output_path, "w") as f:
+        f.write("# Linear Probe Results — CLIP Frozen Embeddings\n\n")
+        f.write(f"**Date:** {__import__('datetime').date.today()}\n")
+        f.write(f"**Model:** ViT-B/32 (laion2b_s34b_b79k)\n")
+        f.write(f"**Embeddings:** 1,927 × 512-dim from product shots\n\n")
+
+        f.write("## Summary\n\n")
+        f.write("| Task | Accuracy | 5-fold CV | Classes | Samples |\n")
+        f.write("|------|----------|-----------|---------|--------|\n")
+        for r in results:
+            f.write(f"| {r['task']} | {r['accuracy']:.1%} | "
+                    f"{r['cv_mean']:.1%} ± {r['cv_std']:.1%} | "
+                    f"{r['n_classes']} | {r['n_samples']} |\n")
+
+        f.write("\n## Decision Gate\n\n")
+        brand_acc = next((r["accuracy"] for r in results if r["task"] == "Brand"), 0)
+        if brand_acc > 0.8:
+            f.write(f"**Brand accuracy: {brand_acc:.1%} → CLIP features work.**\n\n")
+            f.write("CLIP's frozen representations contain enough brand-discriminative signal "
+                    "for visual search. Prompt engineering and embedding-space techniques "
+                    "are sufficient. LoRA fine-tuning is not required.\n\n")
+            f.write("**Next:** Focus investment on battery door classifier and confirmation screen.\n")
+        elif brand_acc > 0.5:
+            f.write(f"**Brand accuracy: {brand_acc:.1%} → Mixed signal.**\n\n")
+            f.write("CLIP features capture some brand structure but not enough for reliable "
+                    "classification. LoRA fine-tuning on hearing aid product shots is worth "
+                    "investigating.\n\n")
+            f.write("**Next:** Run LoRA experiment (Step 6 of forward plan) before "
+                    "investing further in CLIP-based features.\n")
+        else:
+            f.write(f"**Brand accuracy: {brand_acc:.1%} → CLIP doesn't transfer.**\n\n")
+            f.write("Frozen CLIP features do not contain enough signal to distinguish "
+                    "hearing aid brands. The visual similarity between devices across "
+                    "manufacturers is too high for general-purpose embeddings.\n\n")
+            f.write("**Next:** Go all-in on OCR + specialized classifiers. "
+                    "Deprioritize CLIP visual search entirely.\n")
+
+        f.write("\n## Most Confused Pairs\n\n")
+        f.write("These confusions reveal how CLIP's internal representation groups "
+                "hearing aids — and whether those groupings reflect visual similarity, "
+                "OEM relationships, or noise.\n\n")
+        for r in results:
+            f.write(f"### {r['task']}\n\n")
+            if r["confused_pairs"]:
+                for count, true, pred in r["confused_pairs"][:5]:
+                    f.write(f"- **{true}** misclassified as **{pred}**: {count}×\n")
+            else:
+                f.write("No confusions (perfect classification).\n")
+            f.write("\n")
+
+        # Per-task detailed sections
+        for r in results:
+            f.write(f"## {r['task']} — Detailed Results\n\n")
+            f.write(f"Accuracy: {r['accuracy']:.1%} | "
+                    f"5-fold CV: {r['cv_mean']:.1%} ± {r['cv_std']:.1%} | "
+                    f"{r['n_classes']} classes, {r['n_samples']} samples\n\n")
+            f.write("| Class | Precision | Recall | F1 | Support |\n")
+            f.write("|-------|-----------|--------|----|---------|\n")
+            report = r["report"]
+            for cls in r["class_names"]:
+                cr = report[cls]
+                f.write(f"| {cls} | {cr['precision']:.1%} | {cr['recall']:.1%} | "
+                        f"{cr['f1-score']:.1%} | {cr['support']:.0f} |\n")
+            f.write("\n")
+
+    print(f"\n📄 Results written to {output_path}")
+
+
+def plot_results(results, output_dir):
+    """Generate confusion matrix heatmaps and accuracy bar charts."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LogNorm
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(exist_ok=True)
+
+    # ── 1. Confusion matrices ──────────────────────────────────────────
+    for r in results:
+        cm = np.array(r["confusion_matrix"])
+        classes = r["class_names"]
+        n = len(classes)
+
+        fig, ax = plt.subplots(figsize=(max(8, n * 0.7), max(6, n * 0.6)))
+
+        # Normalize by row (true label) for percentage view
+        cm_norm = cm.astype(float) / cm.sum(axis=1, keepdims=True)
+
+        im = ax.imshow(cm_norm, cmap="YlOrRd", vmin=0, vmax=1)
+        fig.colorbar(im, ax=ax, label="Recall (row-normalized)", shrink=0.8)
+
+        # Labels
+        ax.set_xticks(range(n))
+        ax.set_yticks(range(n))
+        short_names = [c[:12] for c in classes]
+        ax.set_xticklabels(short_names, rotation=45, ha="right", fontsize=8)
+        ax.set_yticklabels(short_names, fontsize=8)
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("True")
+        ax.set_title(f"{r['task']} — Confusion Matrix ({r['accuracy']:.1%} accuracy)")
+
+        # Annotate cells with counts
+        for i in range(n):
+            for j in range(n):
+                if cm[i, j] > 0:
+                    color = "white" if cm_norm[i, j] > 0.5 else "black"
+                    ax.text(j, i, str(cm[i, j]), ha="center", va="center",
+                            fontsize=7, color=color)
+
+        fig.tight_layout()
+        path = output_dir / f"probe_{r['task'].lower()}_confusion.png"
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        print(f"  {path}")
+
+    # ── 2. Summary accuracy bar chart ──────────────────────────────────
+    fig, ax = plt.subplots(figsize=(8, 4))
+    tasks = [r["task"] for r in results]
+    accs = [r["accuracy"] for r in results]
+    cvs = [r["cv_mean"] for r in results]
+    cv_errs = [r["cv_std"] for r in results]
+
+    x = np.arange(len(tasks))
+    width = 0.35
+    bars1 = ax.bar(x - width/2, [a * 100 for a in accs], width, label="Test (80/20)", color="#2ecc71")
+    bars2 = ax.bar(x + width/2, [a * 100 for a in cvs], width,
+                   yerr=[e * 100 for e in cv_errs], label="5-fold CV", color="#3498db", capsize=5)
+
+    # Decision gate lines
+    ax.axhline(y=80, color="#e74c3c", linestyle="--", alpha=0.5, label="High confidence (80%)")
+    ax.axhline(y=50, color="#e67e22", linestyle="--", alpha=0.5, label="Low confidence (50%)")
+
+    ax.set_ylabel("Accuracy (%)")
+    ax.set_title("CLIP Linear Probe — Can the AI see the difference?")
+    ax.set_xticks(x)
+    ax.set_xticklabels(tasks)
+    ax.set_ylim(0, 105)
+    ax.legend(loc="lower right", fontsize=8)
+
+    # Value labels on bars
+    for bar in bars1:
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 1,
+                f"{bar.get_height():.0f}%", ha="center", va="bottom", fontsize=9)
+    for bar in bars2:
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 1,
+                f"{bar.get_height():.0f}%", ha="center", va="bottom", fontsize=9)
+
+    fig.tight_layout()
+    path = output_dir / "probe_summary.png"
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+    print(f"  {path}")
+
+    # ── 3. Per-class F1 bar charts ─────────────────────────────────────
+    for r in results:
+        classes = r["class_names"]
+        report = r["report"]
+        f1s = [report[c]["f1-score"] * 100 for c in classes]
+        supports = [report[c]["support"] for c in classes]
+
+        # Sort by F1
+        order = np.argsort(f1s)[::-1]
+        classes_sorted = [classes[i] for i in order]
+        f1s_sorted = [f1s[i] for i in order]
+        supports_sorted = [supports[i] for i in order]
+
+        fig, ax = plt.subplots(figsize=(max(8, len(classes) * 0.5), 5))
+        colors = ["#2ecc71" if f > 80 else "#f39c12" if f > 50 else "#e74c3c" for f in f1s_sorted]
+        bars = ax.bar(range(len(classes_sorted)), f1s_sorted, color=colors)
+
+        ax.set_xticks(range(len(classes_sorted)))
+        ax.set_xticklabels(classes_sorted, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel("F1 Score (%)")
+        ax.set_title(f"{r['task']} — Per-class F1 (green >80%, amber >50%, red <50%)")
+        ax.set_ylim(0, 110)
+
+        # Support labels
+        for i, (bar, n) in enumerate(zip(bars, supports_sorted)):
+            ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 1,
+                    f"n={n:.0f}", ha="center", va="bottom", fontsize=7, color="gray")
+
+        fig.tight_layout()
+        path = output_dir / f"probe_{r['task'].lower()}_f1.png"
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        print(f"  {path}")
+
+    print(f"\n📊 All plots saved to {output_dir}/")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Linear probe on frozen CLIP embeddings")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--real", type=str, help="Directory of real-world photos to test")
+    parser.add_argument("--plot", action="store_true", help="Generate visualisation plots")
+    args = parser.parse_args()
+
+    # Load data
+    X, labels = load_data()
+    print(f"\nEmbedding matrix: {X.shape}")
+
+    # Run three probes
+    results = []
+    for task, y in [("Brand", labels["brand"]), ("Style", labels["style"]), ("Battery", labels["battery"])]:
+        result = run_probe(X, y, task)
+        results.append(result)
+
+    # Real-world domain gap test
+    if args.real:
+        probe_real_photos(args.real, None, results)
+
+    # Generate plots
+    if args.plot:
+        print("\nGenerating plots...")
+        plot_dir = DATA_DIR.parent / "docs" / "plots"
+        plot_results(results, plot_dir)
+
+    # Write results document
+    docs_dir = DATA_DIR.parent / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    write_results_doc(results, docs_dir / "linear-probe-results.md")
+
+    # JSON output
+    if args.json:
+        # Strip non-serializable fields
+        json_results = []
+        for r in results:
+            jr = {k: v for k, v in r.items() if k != "classifier"}
+            json_results.append(jr)
+        print(json.dumps(json_results, indent=2, default=str))
+
+    # Print decision gate summary
+    brand_acc = next((r["accuracy"] for r in results if r["task"] == "Brand"), 0)
+    style_acc = next((r["accuracy"] for r in results if r["task"] == "Style"), 0)
+    battery_acc = next((r["accuracy"] for r in results if r["task"] == "Battery"), 0)
+
+    print(f"\n{'='*60}")
+    print(f"DECISION GATE")
+    print(f"{'='*60}")
+    print(f"  Brand:   {brand_acc:.1%}", end="")
+    print(f"  {'✅ CLIP works' if brand_acc > 0.8 else '⚠️  Mixed' if brand_acc > 0.5 else '❌ CLIP fails'}")
+    print(f"  Style:   {style_acc:.1%}", end="")
+    print(f"  {'→ AI-assisted on confirmation screen' if style_acc > 0.7 else '→ human-only field'}")
+    print(f"  Battery: {battery_acc:.1%}", end="")
+    print(f"  {'→ AI-assisted on confirmation screen' if battery_acc > 0.7 else '→ human-only field'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/models/brand_classifier_labels.json
+++ b/data/models/brand_classifier_labels.json
@@ -1,0 +1,18 @@
+{
+  "classes": [
+    "Beltone",
+    "Bernafon",
+    "Oticon",
+    "Philips",
+    "Phonak",
+    "ReSound",
+    "Signia",
+    "Starkey",
+    "Unitron",
+    "Widex"
+  ],
+  "num_classes": 10,
+  "input_size": 224,
+  "quantized": true,
+  "quantization": "float16"
+}

--- a/data/train_brand_classifier.py
+++ b/data/train_brand_classifier.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Train a hearing aid brand classifier using EfficientNet-B0 transfer learning.
+
+Uses the 2,267 product images from unaudinary.com, labelled by brand via
+visual_embeddings.json. Fine-tunes with aggressive augmentation to bridge
+the domain gap between product shots and real-world hand-held photos.
+
+Exports:
+  - brand_classifier.tflite  (quantized, ~13MB, for on-device inference)
+  - brand_classifier_labels.json (class names + training metadata)
+
+Usage:
+  python3 train_brand_classifier.py              # train + export
+  python3 train_brand_classifier.py --epochs 30  # more epochs
+  python3 train_brand_classifier.py --test-only  # evaluate existing model
+
+Requires: tensorflow, Pillow
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+# Suppress TF warnings
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+import tensorflow as tf
+
+
+DATA_DIR = Path(__file__).parent
+IMAGE_DIR = DATA_DIR / "images"
+PROCESSED_DIR = DATA_DIR / "processed"
+ORGANISED_DIR = DATA_DIR / "images_by_brand"
+MODEL_DIR = DATA_DIR / "models"
+
+# Training params
+IMG_SIZE = 224  # EfficientNet-B0 native input
+BATCH_SIZE = 32
+DEFAULT_EPOCHS = 20
+MIN_IMAGES_PER_BRAND = 30  # Skip brands with too few images
+
+# Brands to merge (sub-brands → parent)
+BRAND_ALIASES = {
+    "Specsavers Advance": None,  # Drop — white-label, not identifiable
+    "Hearing Australia": None,   # Drop — white-label
+    "Hansaton": "Signia",        # Same parent (WS Audiology)
+    "Rexton": "Signia",         # Same parent (WS Audiology)
+    "Amplifon": None,           # Drop — white-label
+    "Jabra": "ReSound",         # Same parent (GN Group)
+}
+
+
+def organise_images():
+    """Symlink images into brand subfolders for tf.keras dataset loading."""
+    print("Organising images by brand...")
+
+    with open(PROCESSED_DIR / "visual_embeddings.json") as f:
+        entries = json.load(f)
+
+    # Build image → brand mapping (use first device's manufacturer)
+    image_brands = {}
+    for entry in entries:
+        path = entry.get("local_path", "")
+        devices = entry.get("devices", [])
+        if not devices or not path:
+            continue
+
+        brand = devices[0].get("manufacturer", "")
+        if not brand:
+            continue
+
+        # Apply aliases
+        if brand in BRAND_ALIASES:
+            brand = BRAND_ALIASES[brand]
+            if brand is None:
+                continue  # Drop this brand
+
+        image_brands[path] = brand
+
+    # Count brands
+    brand_counts = Counter(image_brands.values())
+    print(f"\nBrand distribution (before filtering):")
+    for brand, count in brand_counts.most_common():
+        marker = " ✓" if count >= MIN_IMAGES_PER_BRAND else " ✗ (too few)"
+        print(f"  {brand}: {count}{marker}")
+
+    # Filter brands with too few images
+    valid_brands = {b for b, c in brand_counts.items() if c >= MIN_IMAGES_PER_BRAND}
+    print(f"\nKeeping {len(valid_brands)} brands with ≥{MIN_IMAGES_PER_BRAND} images")
+
+    # Create symlinks
+    if ORGANISED_DIR.exists():
+        shutil.rmtree(ORGANISED_DIR)
+
+    created = 0
+    skipped = 0
+    for rel_path, brand in image_brands.items():
+        if brand not in valid_brands:
+            continue
+
+        src = IMAGE_DIR / rel_path
+        if not src.exists():
+            skipped += 1
+            continue
+
+        dest_dir = ORGANISED_DIR / brand
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / src.name
+
+        if not dest.exists():
+            os.symlink(src.resolve(), dest)
+            created += 1
+
+    print(f"\nCreated {created} symlinks, skipped {skipped} missing images")
+    return valid_brands
+
+
+def create_datasets(valid_brands):
+    """Create train/val datasets with augmentation."""
+    print("\nLoading datasets...")
+
+    # Training dataset with augmentation
+    train_ds = tf.keras.utils.image_dataset_from_directory(
+        str(ORGANISED_DIR),
+        validation_split=0.2,
+        subset="training",
+        seed=42,
+        image_size=(IMG_SIZE, IMG_SIZE),
+        batch_size=BATCH_SIZE,
+        label_mode="categorical",
+    )
+
+    val_ds = tf.keras.utils.image_dataset_from_directory(
+        str(ORGANISED_DIR),
+        validation_split=0.2,
+        subset="validation",
+        seed=42,
+        image_size=(IMG_SIZE, IMG_SIZE),
+        batch_size=BATCH_SIZE,
+        label_mode="categorical",
+    )
+
+    class_names = train_ds.class_names
+    num_classes = len(class_names)
+    print(f"\nClasses ({num_classes}): {class_names}")
+    print(f"Train batches: {tf.data.experimental.cardinality(train_ds).numpy()}")
+    print(f"Val batches: {tf.data.experimental.cardinality(val_ds).numpy()}")
+
+    # Aggressive augmentation to bridge product-shot → real-world domain gap
+    augmentation = tf.keras.Sequential([
+        tf.keras.layers.RandomFlip("horizontal"),
+        tf.keras.layers.RandomRotation(0.15),        # ±54°
+        tf.keras.layers.RandomZoom((-0.2, 0.2)),     # 80-120% zoom
+        tf.keras.layers.RandomBrightness(0.2),       # ±20% brightness
+        tf.keras.layers.RandomContrast(0.2),         # ±20% contrast
+        tf.keras.layers.RandomTranslation(0.1, 0.1), # ±10% shift
+    ], name="augmentation")
+
+    # Apply augmentation only to training
+    train_ds = train_ds.map(
+        lambda x, y: (augmentation(x, training=True), y),
+        num_parallel_calls=tf.data.AUTOTUNE,
+    )
+
+    # Prefetch for performance
+    train_ds = train_ds.prefetch(tf.data.AUTOTUNE)
+    val_ds = val_ds.prefetch(tf.data.AUTOTUNE)
+
+    return train_ds, val_ds, class_names, num_classes
+
+
+def build_model(num_classes):
+    """Build EfficientNet-B0 with frozen backbone + trainable head."""
+    print("\nBuilding model...")
+
+    # EfficientNet-B0: 5.3M params, good accuracy/speed tradeoff for mobile
+    base_model = tf.keras.applications.EfficientNetB0(
+        input_shape=(IMG_SIZE, IMG_SIZE, 3),
+        include_top=False,
+        weights="imagenet",
+    )
+    base_model.trainable = False  # Freeze backbone initially
+
+    model = tf.keras.Sequential([
+        # EfficientNet includes its own preprocessing (scaling to [0, 255])
+        base_model,
+        tf.keras.layers.GlobalAveragePooling2D(),
+        tf.keras.layers.Dropout(0.3),
+        tf.keras.layers.Dense(128, activation="relu"),
+        tf.keras.layers.Dropout(0.2),
+        tf.keras.layers.Dense(num_classes, activation="softmax"),
+    ])
+
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+
+    total_params = model.count_params()
+    trainable_params = sum(
+        tf.keras.backend.count_params(w) for w in model.trainable_weights
+    )
+    print(f"Total params: {total_params:,}")
+    print(f"Trainable params: {trainable_params:,} (head only)")
+
+    return model, base_model
+
+
+def fine_tune_backbone(model, base_model, train_ds, val_ds, epochs=10):
+    """Unfreeze top layers of backbone for fine-tuning."""
+    print("\n── Fine-tuning backbone (top 30 layers) ──")
+
+    base_model.trainable = True
+    # Freeze everything except the top 30 layers
+    for layer in base_model.layers[:-30]:
+        layer.trainable = False
+
+    trainable_params = sum(
+        tf.keras.backend.count_params(w) for w in model.trainable_weights
+    )
+    print(f"Trainable params after unfreeze: {trainable_params:,}")
+
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=1e-5),  # Lower LR
+        loss="categorical_crossentropy",
+        metrics=["accuracy"],
+    )
+
+    history = model.fit(
+        train_ds,
+        validation_data=val_ds,
+        epochs=epochs,
+        callbacks=[
+            tf.keras.callbacks.EarlyStopping(
+                monitor="val_accuracy",
+                patience=5,
+                restore_best_weights=True,
+            ),
+            tf.keras.callbacks.ReduceLROnPlateau(
+                monitor="val_loss",
+                factor=0.5,
+                patience=3,
+            ),
+        ],
+    )
+    return history
+
+
+def export_tflite(model, class_names):
+    """Export to quantized TFLite for on-device inference."""
+    MODEL_DIR.mkdir(exist_ok=True)
+
+    # Full precision first (for accuracy comparison)
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    tflite_fp32 = converter.convert()
+    fp32_path = MODEL_DIR / "brand_classifier_fp32.tflite"
+    fp32_path.write_bytes(tflite_fp32)
+    print(f"\nFP32 model: {fp32_path} ({len(tflite_fp32) / 1e6:.1f} MB)")
+
+    # Dynamic range quantization (best size/accuracy tradeoff)
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    tflite_quant = converter.convert()
+    quant_path = MODEL_DIR / "brand_classifier.tflite"
+    quant_path.write_bytes(tflite_quant)
+    print(f"Quantized model: {quant_path} ({len(tflite_quant) / 1e6:.1f} MB)")
+
+    # Save labels + metadata
+    labels = {
+        "classes": class_names,
+        "num_classes": len(class_names),
+        "input_size": IMG_SIZE,
+        "quantized": True,
+        "brand_aliases": BRAND_ALIASES,
+    }
+    labels_path = MODEL_DIR / "brand_classifier_labels.json"
+    with open(labels_path, "w") as f:
+        json.dump(labels, f, indent=2)
+    print(f"Labels: {labels_path}")
+
+    return quant_path
+
+
+def evaluate_tflite(tflite_path, val_ds, class_names):
+    """Run TFLite model on validation set to verify accuracy."""
+    print(f"\nEvaluating TFLite model: {tflite_path}")
+
+    interpreter = tf.lite.Interpreter(model_path=str(tflite_path))
+    interpreter.allocate_tensors()
+
+    input_details = interpreter.get_input_details()
+    output_details = interpreter.get_output_details()
+
+    correct = 0
+    total = 0
+
+    for images, labels in val_ds:
+        for i in range(images.shape[0]):
+            img = tf.expand_dims(images[i], 0)
+            # Ensure float32 input
+            if input_details[0]["dtype"] == np.float32:
+                img = tf.cast(img, tf.float32)
+
+            interpreter.set_tensor(input_details[0]["index"], img.numpy())
+            interpreter.invoke()
+            output = interpreter.get_tensor(output_details[0]["index"])
+
+            pred = np.argmax(output[0])
+            true = np.argmax(labels[i].numpy())
+            if pred == true:
+                correct += 1
+            total += 1
+
+    accuracy = correct / total if total > 0 else 0
+    print(f"TFLite accuracy: {accuracy:.1%} ({correct}/{total})")
+    return accuracy
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train hearing aid brand classifier")
+    parser.add_argument("--epochs", type=int, default=DEFAULT_EPOCHS,
+                        help=f"Head training epochs (default: {DEFAULT_EPOCHS})")
+    parser.add_argument("--fine-tune-epochs", type=int, default=10,
+                        help="Backbone fine-tuning epochs (default: 10)")
+    parser.add_argument("--test-only", action="store_true",
+                        help="Evaluate existing model without training")
+    parser.add_argument("--no-fine-tune", action="store_true",
+                        help="Skip backbone fine-tuning")
+    args = parser.parse_args()
+
+    # Check for MPS (Apple Silicon) or GPU
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        print(f"GPU available: {gpus}")
+    elif hasattr(tf, "config") and tf.config.list_physical_devices("GPU"):
+        print("MPS (Apple Silicon) available")
+    else:
+        print("No GPU detected — training on CPU (slower)")
+
+    # Step 1: Organise images
+    valid_brands = organise_images()
+
+    if not ORGANISED_DIR.exists() or not any(ORGANISED_DIR.iterdir()):
+        print("\nERROR: No images found. Run download_images.py first.")
+        sys.exit(1)
+
+    # Step 2: Create datasets
+    train_ds, val_ds, class_names, num_classes = create_datasets(valid_brands)
+
+    if args.test_only:
+        tflite_path = MODEL_DIR / "brand_classifier.tflite"
+        if not tflite_path.exists():
+            print(f"ERROR: {tflite_path} not found")
+            sys.exit(1)
+        evaluate_tflite(tflite_path, val_ds, class_names)
+        return
+
+    # Step 3: Train head
+    print(f"\n── Training head ({args.epochs} epochs) ──")
+    model, base_model = build_model(num_classes)
+    history = model.fit(
+        train_ds,
+        validation_data=val_ds,
+        epochs=args.epochs,
+        callbacks=[
+            tf.keras.callbacks.EarlyStopping(
+                monitor="val_accuracy",
+                patience=5,
+                restore_best_weights=True,
+            ),
+        ],
+    )
+
+    head_acc = max(history.history["val_accuracy"])
+    print(f"\nBest head-only val accuracy: {head_acc:.1%}")
+
+    # Step 4: Fine-tune backbone
+    if not args.no_fine_tune:
+        ft_history = fine_tune_backbone(
+            model, base_model, train_ds, val_ds, epochs=args.fine_tune_epochs,
+        )
+        ft_acc = max(ft_history.history["val_accuracy"])
+        print(f"\nBest fine-tuned val accuracy: {ft_acc:.1%}")
+
+    # Step 5: Export
+    tflite_path = export_tflite(model, class_names)
+
+    # Step 6: Verify TFLite accuracy
+    evaluate_tflite(tflite_path, val_ds, class_names)
+
+    print("\n✅ Done! Model ready for on-device deployment.")
+    print(f"   Copy {tflite_path} to recycled_sound/assets/")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/linear-probe-results.md
+++ b/docs/linear-probe-results.md
@@ -1,0 +1,98 @@
+# Linear Probe Results — CLIP Frozen Embeddings
+
+**Date:** 2026-04-08
+**Model:** ViT-B/32 (laion2b_s34b_b79k)
+**Embeddings:** 1,927 × 512-dim from product shots
+
+## Summary
+
+| Task | Accuracy | 5-fold CV | Classes | Samples |
+|------|----------|-----------|---------|--------|
+| Brand | 69.7% | 71.6% ± 1.6% | 16 | 1927 |
+| Style | 91.2% | 92.2% ± 1.0% | 6 | 1927 |
+| Battery | 78.7% | 78.4% ± 1.5% | 5 | 1925 |
+
+## Decision Gate
+
+**Brand accuracy: 69.7% → Mixed signal.**
+
+CLIP features capture some brand structure but not enough for reliable classification. LoRA fine-tuning on hearing aid product shots is worth investigating.
+
+**Next:** Run LoRA experiment (Step 6 of forward plan) before investing further in CLIP-based features.
+
+## Most Confused Pairs
+
+These confusions reveal how CLIP's internal representation groups hearing aids — and whether those groupings reflect visual similarity, OEM relationships, or noise.
+
+### Brand
+
+- **ReSound** misclassified as **Hearing Australia**: 13×
+- **Unitron** misclassified as **Specsavers Advance**: 11×
+- **Hearing Australia** misclassified as **ReSound**: 11×
+- **Signia** misclassified as **Specsavers Advance**: 9×
+- **Specsavers Advance** misclassified as **ReSound**: 6×
+
+### Style
+
+- **BTE** misclassified as **RIC**: 10×
+- **ITC** misclassified as **ITE**: 5×
+- **RIC** misclassified as **BTE**: 4×
+- **IIC** misclassified as **CIC**: 4×
+- **IIC** misclassified as **RIC**: 3×
+
+### Battery
+
+- **312** misclassified as **Rechargeable**: 27×
+- **13** misclassified as **Rechargeable**: 17×
+- **Rechargeable** misclassified as **312**: 9×
+- **675** misclassified as **Rechargeable**: 8×
+- **13** misclassified as **312**: 5×
+
+## Brand — Detailed Results
+
+Accuracy: 69.7% | 5-fold CV: 71.6% ± 1.6% | 16 classes, 1927 samples
+
+| Class | Precision | Recall | F1 | Support |
+|-------|-----------|--------|----|---------|
+| Amplifon | 0.0% | 0.0% | 0.0% | 2 |
+| Beltone | 88.2% | 57.7% | 69.8% | 26 |
+| Bernafon | 84.0% | 95.5% | 89.4% | 44 |
+| Hansaton | 100.0% | 16.7% | 28.6% | 6 |
+| Hearing Australia | 37.5% | 53.6% | 44.1% | 28 |
+| Jabra | 0.0% | 0.0% | 0.0% | 8 |
+| Oticon | 84.2% | 97.0% | 90.1% | 33 |
+| Philips | 100.0% | 45.5% | 62.5% | 11 |
+| Phonak | 97.1% | 94.4% | 95.8% | 36 |
+| ReSound | 46.9% | 62.2% | 53.5% | 37 |
+| Rexton | 91.7% | 50.0% | 64.7% | 22 |
+| Signia | 71.4% | 64.5% | 67.8% | 31 |
+| Specsavers Advance | 34.5% | 51.4% | 41.3% | 37 |
+| Starkey | 100.0% | 83.3% | 90.9% | 12 |
+| Unitron | 75.0% | 35.3% | 48.0% | 17 |
+| Widex | 94.7% | 100.0% | 97.3% | 36 |
+
+## Style — Detailed Results
+
+Accuracy: 91.2% | 5-fold CV: 92.2% ± 1.0% | 6 classes, 1927 samples
+
+| Class | Precision | Recall | F1 | Support |
+|-------|-----------|--------|----|---------|
+| BTE | 95.5% | 91.5% | 93.4% | 117 |
+| CIC | 89.2% | 86.8% | 88.0% | 38 |
+| IIC | 92.3% | 63.2% | 75.0% | 19 |
+| ITC | 92.3% | 82.8% | 87.3% | 29 |
+| ITE | 85.2% | 93.9% | 89.3% | 49 |
+| RIC | 90.3% | 97.0% | 93.5% | 134 |
+
+## Battery — Detailed Results
+
+Accuracy: 78.7% | 5-fold CV: 78.4% ± 1.5% | 5 classes, 1925 samples
+
+| Class | Precision | Recall | F1 | Support |
+|-------|-----------|--------|----|---------|
+| 10 | 94.0% | 87.0% | 90.4% | 54 |
+| 13 | 80.6% | 53.2% | 64.1% | 47 |
+| 312 | 82.7% | 75.0% | 78.6% | 108 |
+| 675 | 0.0% | 0.0% | 0.0% | 12 |
+| Rechargeable | 72.8% | 91.5% | 81.1% | 164 |
+

--- a/recycled_sound/assets/brand_classifier_labels.json
+++ b/recycled_sound/assets/brand_classifier_labels.json
@@ -1,0 +1,18 @@
+{
+  "classes": [
+    "Beltone",
+    "Bernafon",
+    "Oticon",
+    "Philips",
+    "Phonak",
+    "ReSound",
+    "Signia",
+    "Starkey",
+    "Unitron",
+    "Widex"
+  ],
+  "num_classes": 10,
+  "input_size": 224,
+  "quantized": true,
+  "quantization": "float16"
+}

--- a/recycled_sound/ios/Podfile.lock
+++ b/recycled_sound/ios/Podfile.lock
@@ -1454,6 +1454,28 @@ PODS:
   - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
   - RecaptchaInterop (101.0.0)
+  - TensorFlowLiteC (2.12.0):
+    - TensorFlowLiteC/Core (= 2.12.0)
+  - TensorFlowLiteC/Core (2.12.0)
+  - TensorFlowLiteC/CoreML (2.12.0):
+    - TensorFlowLiteC/Core
+  - TensorFlowLiteC/Metal (2.12.0):
+    - TensorFlowLiteC/Core
+  - TensorFlowLiteSwift (2.12.0):
+    - TensorFlowLiteSwift/Core (= 2.12.0)
+  - TensorFlowLiteSwift/Core (2.12.0):
+    - TensorFlowLiteC (= 2.12.0)
+  - TensorFlowLiteSwift/CoreML (2.12.0):
+    - TensorFlowLiteC/CoreML (= 2.12.0)
+    - TensorFlowLiteSwift/Core (= 2.12.0)
+  - TensorFlowLiteSwift/Metal (2.12.0):
+    - TensorFlowLiteC/Metal (= 2.12.0)
+    - TensorFlowLiteSwift/Core (= 2.12.0)
+  - tflite_flutter (0.0.1):
+    - Flutter
+    - TensorFlowLiteSwift (= 2.12.0)
+    - TensorFlowLiteSwift/CoreML (= 2.12.0)
+    - TensorFlowLiteSwift/Metal (= 2.12.0)
 
 DEPENDENCIES:
   - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
@@ -1466,6 +1488,7 @@ DEPENDENCIES:
   - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
   - google_mlkit_text_recognition (from `.symlinks/plugins/google_mlkit_text_recognition/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - tflite_flutter (from `.symlinks/plugins/tflite_flutter/ios`)
 
 SPEC REPOS:
   trunk:
@@ -1500,6 +1523,8 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - RecaptchaInterop
+    - TensorFlowLiteC
+    - TensorFlowLiteSwift
 
 EXTERNAL SOURCES:
   camera_avfoundation:
@@ -1522,6 +1547,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_mlkit_text_recognition/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  tflite_flutter:
+    :path: ".symlinks/plugins/tflite_flutter/ios"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1565,6 +1592,9 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  TensorFlowLiteC: 20785a69299185a379ba9852b6625f00afd7984a
+  TensorFlowLiteSwift: 3a4928286e9e35bdd3e17970f48e53c80d25e793
+  tflite_flutter: 9433d086a3060431bbc9f3c7c20d017db0e72d08
 
 PODFILE CHECKSUM: 3b656f0f4c966a0a610ec622e26f670df13eb350
 

--- a/recycled_sound/lib/core/routing/app_router.dart
+++ b/recycled_sound/lib/core/routing/app_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../features/home/presentation/home_screen.dart';
 import '../../features/scanner/presentation/live_scanner_screen.dart';
 import '../../features/scanner/presentation/analysing_screen.dart';
+import '../../features/scanner/presentation/confirmation_screen.dart';
 import '../../features/scanner/presentation/results_screen.dart';
 import '../../features/devices/presentation/device_list_screen.dart';
 import '../../features/devices/presentation/device_detail_screen.dart';
@@ -57,6 +58,11 @@ final appRouter = GoRouter(
         final scanId = state.extra as String? ?? '';
         return ResultsScreen(scanId: scanId);
       },
+    ),
+    GoRoute(
+      path: '/scan/confirm',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const ConfirmationScreen(),
     ),
     GoRoute(
       path: '/devices/:id',

--- a/recycled_sound/lib/core/theme/app_typography.dart
+++ b/recycled_sound/lib/core/theme/app_typography.dart
@@ -40,4 +40,48 @@ abstract final class AppTypography {
       _base.copyWith(fontSize: 14, fontWeight: FontWeight.w600, height: 1.2);
   static TextStyle get nav =>
       _base.copyWith(fontSize: 9, fontWeight: FontWeight.w500, height: 1.2);
+
+  // ── Scanner / T2 HUD monospace ──────────────────────────────────────
+  // Used by the live scanner HUD and confirmation screen for the
+  // technical readout aesthetic.
+
+  static const _monoBase = TextStyle(fontFamily: 'monospace');
+
+  /// HUD field label (e.g. "MAKE", "COLOUR").
+  static TextStyle get monoLabel => _monoBase.copyWith(
+      fontSize: 11,
+      fontWeight: FontWeight.w600,
+      color: const Color(0xFF888888),
+      letterSpacing: 1.0);
+
+  /// HUD field value — detected.
+  static TextStyle get monoValue => _monoBase.copyWith(
+      fontSize: 13, fontWeight: FontWeight.w600, letterSpacing: 0.3);
+
+  /// HUD field value — large (confirmation screen).
+  static TextStyle get monoValueLarge => _monoBase.copyWith(
+      fontSize: 15, fontWeight: FontWeight.w600, letterSpacing: 0.3);
+
+  /// HUD small text (cross-ref flash, badges).
+  static TextStyle get monoSmall => _monoBase.copyWith(
+      fontSize: 9,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.5);
+
+  /// HUD micro text (swatch labels, brand palette badge).
+  static TextStyle get monoMicro => _monoBase.copyWith(
+      fontSize: 8,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.8);
+
+  /// HUD status text (counter, button labels).
+  static TextStyle get monoStatus => _monoBase.copyWith(
+      fontSize: 11,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 1.2);
+
+  /// HUD button/action text.
+  static TextStyle get monoButton => _monoBase.copyWith(
+      fontSize: 13,
+      fontWeight: FontWeight.w500);
 }

--- a/recycled_sound/lib/features/home/presentation/home_screen.dart
+++ b/recycled_sound/lib/features/home/presentation/home_screen.dart
@@ -88,6 +88,13 @@ class HomeScreen extends StatelessWidget {
                 subtitle: 'View all collected hearing aids',
                 onTap: () => context.go('/devices'),
               ),
+              const SizedBox(height: 8),
+              _ActionTile(
+                icon: Icons.assignment_turned_in,
+                title: '7-Field Confirmation',
+                subtitle: 'Preview with mock scan data',
+                onTap: () => context.push('/scan/confirm'),
+              ),
             ],
           ),
         ),

--- a/recycled_sound/lib/features/scanner/data/brand_classifier.dart
+++ b/recycled_sound/lib/features/scanner/data/brand_classifier.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:image/image.dart' as img;
+import 'package:tflite_flutter/tflite_flutter.dart';
+
+/// Result of on-device brand classification.
+class BrandPrediction {
+  const BrandPrediction({
+    required this.brand,
+    required this.confidence,
+    required this.allProbabilities,
+  });
+
+  /// Predicted brand name, e.g. "Unitron".
+  final String brand;
+
+  /// Confidence 0.0–1.0 for the top prediction.
+  final double confidence;
+
+  /// Probabilities for all classes, sorted descending.
+  final List<({String brand, double probability})> allProbabilities;
+
+  /// Top-N predictions above a confidence threshold.
+  List<({String brand, double probability})> topN(int n,
+          {double minConfidence = 0.05}) =>
+      allProbabilities
+          .where((p) => p.probability >= minConfidence)
+          .take(n)
+          .toList();
+}
+
+/// On-device hearing aid brand classifier using EfficientNet-B0 (TFLite).
+///
+/// Runs on the Neural Engine (iOS A12+) or GPU (Android) via TFLite delegates.
+/// Model is 4.7MB quantized, ~10ms inference on iPhone 14 Pro.
+///
+/// Usage:
+/// ```dart
+/// final classifier = BrandClassifier();
+/// await classifier.load();
+/// final prediction = await classifier.classifyFile(imagePath);
+/// print('${prediction.brand} (${prediction.confidence})');
+/// ```
+class BrandClassifier {
+  Interpreter? _interpreter;
+  List<String> _classes = [];
+  int _inputSize = 224;
+  bool _loaded = false;
+
+  /// Whether the model has been loaded successfully.
+  bool get isLoaded => _loaded;
+
+  /// Load the TFLite model and labels from assets.
+  Future<void> load() async {
+    if (_loaded) return;
+
+    // Load labels
+    final labelsJson =
+        await rootBundle.loadString('assets/brand_classifier_labels.json');
+    final labels = jsonDecode(labelsJson) as Map<String, dynamic>;
+    _classes = List<String>.from(labels['classes'] as List);
+    _inputSize = labels['input_size'] as int? ?? 224;
+
+    // Load TFLite model via rootBundle → file → interpreter.
+    // This avoids tflite_flutter's asset resolution quirks.
+    final modelData =
+        await rootBundle.load('assets/brand_classifier.tflite');
+
+    final options = InterpreterOptions();
+
+    // On iOS, TFLite automatically uses CoreML delegate (Neural Engine)
+    // On Android, explicitly request GPU delegate
+    if (Platform.isAndroid) {
+      options.addDelegate(GpuDelegateV2());
+    }
+
+    _interpreter = Interpreter.fromBuffer(modelData.buffer.asUint8List(),
+        options: options);
+    _loaded = true;
+  }
+
+  /// Classify a hearing aid image from a file path.
+  ///
+  /// Returns brand prediction with confidence and all class probabilities.
+  Future<BrandPrediction> classifyFile(String imagePath) async {
+    if (!_loaded) await load();
+
+    final bytes = await File(imagePath).readAsBytes();
+    final image = img.decodeImage(bytes);
+    if (image == null) {
+      throw Exception('Failed to decode image: $imagePath');
+    }
+
+    return _classify(image);
+  }
+
+  /// Classify from raw image bytes (e.g. from camera capture).
+  Future<BrandPrediction> classifyBytes(Uint8List bytes) async {
+    if (!_loaded) await load();
+
+    final image = img.decodeImage(bytes);
+    if (image == null) {
+      throw Exception('Failed to decode image bytes');
+    }
+
+    return _classify(image);
+  }
+
+  BrandPrediction _classify(img.Image image) {
+    // Resize to model input size
+    final resized =
+        img.copyResize(image, width: _inputSize, height: _inputSize);
+
+    // Build input tensor [1, 224, 224, 3] as Float32
+    // EfficientNet expects pixel values in [0, 255] (its own preprocessing
+    // handles normalization internally)
+    final input = List.generate(
+      1,
+      (_) => List.generate(
+        _inputSize,
+        (y) => List.generate(
+          _inputSize,
+          (x) {
+            final pixel = resized.getPixel(x, y);
+            return [pixel.r.toDouble(), pixel.g.toDouble(), pixel.b.toDouble()];
+          },
+        ),
+      ),
+    );
+
+    // Output: [1, num_classes] probabilities
+    final output = List.generate(1, (_) => List.filled(_classes.length, 0.0));
+
+    _interpreter!.run(input, output);
+
+    final probs = output[0];
+
+    // Build sorted predictions
+    final predictions = <({String brand, double probability})>[];
+    for (var i = 0; i < _classes.length; i++) {
+      predictions.add((brand: _classes[i], probability: probs[i]));
+    }
+    predictions.sort((a, b) => b.probability.compareTo(a.probability));
+
+    return BrandPrediction(
+      brand: predictions.first.brand,
+      confidence: predictions.first.probability,
+      allProbabilities: predictions,
+    );
+  }
+
+  /// Release model resources.
+  void dispose() {
+    _interpreter?.close();
+    _interpreter = null;
+    _loaded = false;
+  }
+}

--- a/recycled_sound/lib/features/scanner/data/brand_colour_palettes.dart
+++ b/recycled_sound/lib/features/scanner/data/brand_colour_palettes.dart
@@ -1,0 +1,105 @@
+import 'dart:ui' show Color;
+
+/// A manufacturer's named colour option for a hearing aid.
+class BrandColour {
+  const BrandColour(this.name, this.color);
+
+  /// Manufacturer's colour name, e.g. "Sand Beige", "Chroma Beige".
+  final String name;
+
+  /// Approximate sRGB colour for the swatch.
+  final Color color;
+}
+
+/// Brand-specific colour palettes for hearing aid manufacturers.
+///
+/// When the scanner identifies a brand, these palettes narrow the colour
+/// choice from the generic CIELAB palette (10 colours) to the manufacturer's
+/// actual named colours (~5-8 per brand). The audiologist taps the exact
+/// manufacturer colour name — faster and more precise than free text.
+///
+/// Sources: manufacturer product pages, fitting software colour pickers.
+abstract final class BrandColourPalettes {
+  /// Returns the colour palette for a brand, or null if unknown.
+  static List<BrandColour>? forBrand(String brand) =>
+      _palettes[brand.toLowerCase()];
+
+  /// All brands that have palettes.
+  static Iterable<String> get knownBrands => _palettes.keys;
+
+  static const _palettes = <String, List<BrandColour>>{
+    'phonak': [
+      BrandColour('Sand Beige', Color(0xFFD4B896)),
+      BrandColour('Champagne', Color(0xFFE8D5B7)),
+      BrandColour('Silver Grey', Color(0xFFA8A9AD)),
+      BrandColour('Graphite Grey', Color(0xFF5C5C5C)),
+      BrandColour('Velvet Black', Color(0xFF2C2C2C)),
+      BrandColour('Sandalwood', Color(0xFFC4A882)),
+    ],
+    'oticon': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Silver', Color(0xFFA8A9AD)),
+      BrandColour('Chroma Beige', Color(0xFFCBB78E)),
+      BrandColour('Diamond Black', Color(0xFF2A2A2A)),
+      BrandColour('Terracotta', Color(0xFFBE7B5E)),
+      BrandColour('Steel Grey', Color(0xFF71797E)),
+    ],
+    'signia': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Silver', Color(0xFFA8A9AD)),
+      BrandColour('Graphite', Color(0xFF5C5C5C)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+      BrandColour('Rose Gold', Color(0xFFC9A087)),
+      BrandColour('Espresso', Color(0xFF4A3728)),
+    ],
+    'widex': [
+      BrandColour('Autumn Beige', Color(0xFFD4B896)),
+      BrandColour('Champagne', Color(0xFFE8D5B7)),
+      BrandColour('Silver Dawn', Color(0xFFB0B0B0)),
+      BrandColour('Toffee', Color(0xFF8B5E3C)),
+      BrandColour('Dark Slate', Color(0xFF4A4A4A)),
+      BrandColour('Midnight Black', Color(0xFF1A1A1A)),
+    ],
+    'resound': [
+      BrandColour('Warm Beige', Color(0xFFD4B896)),
+      BrandColour('Light Blonde', Color(0xFFE8D5B7)),
+      BrandColour('Dark Grey', Color(0xFF5C5C5C)),
+      BrandColour('Sterling', Color(0xFFA8A9AD)),
+      BrandColour('Cobalt Blue', Color(0xFF304B7A)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+    ],
+    'starkey': [
+      BrandColour('Champagne', Color(0xFFE8D5B7)),
+      BrandColour('Silver', Color(0xFFA8A9AD)),
+      BrandColour('Espresso', Color(0xFF4A3728)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+      BrandColour('Cool Grey', Color(0xFF8D9093)),
+    ],
+    'unitron': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Champagne', Color(0xFFE8D5B7)),
+      BrandColour('Silver Grey', Color(0xFFA8A9AD)),
+      BrandColour('Espresso', Color(0xFF4A3728)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+    ],
+    'bernafon': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Silver Grey', Color(0xFFA8A9AD)),
+      BrandColour('Graphite', Color(0xFF5C5C5C)),
+      BrandColour('Chestnut', Color(0xFF8B5E3C)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+    ],
+    'beltone': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Silver', Color(0xFFA8A9AD)),
+      BrandColour('Champagne', Color(0xFFE8D5B7)),
+      BrandColour('Dark Grey', Color(0xFF5C5C5C)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+    ],
+    'blamey saunders': [
+      BrandColour('Beige', Color(0xFFD4B896)),
+      BrandColour('Silver', Color(0xFFA8A9AD)),
+      BrandColour('Black', Color(0xFF2C2C2C)),
+    ],
+  };
+}

--- a/recycled_sound/lib/features/scanner/data/brand_matcher.dart
+++ b/recycled_sound/lib/features/scanner/data/brand_matcher.dart
@@ -61,6 +61,9 @@ class BrandMatcher {
     'blamey & saunders': 'Blamey Saunders',
     'specsavers': 'Specsavers Advance',
     'hearing australia': 'Hearing Australia',
+    // Demant group brands
+    'sonic': 'Sonic',
+    'sonic innovations': 'Sonic',
   };
 
   /// Minimum text length to attempt matching. Short strings produce
@@ -107,6 +110,41 @@ class BrandMatcher {
       if (dist <= _maxDistance) {
         return BrandMatchResult(
             displayName: entry.value, distance: dist, matchType: 'FUZZY');
+      }
+    }
+
+    return null;
+  }
+
+  /// Reverse-lookup: given OCR text, check if it matches a known model
+  /// across ALL brands. Returns (brand, modelText) if found.
+  ///
+  /// This allows model text like "moxi2 kiss" to identify both the brand
+  /// (Unitron) and the model, even when the brand name isn't visible.
+  ///
+  /// More conservative than brand-specific matching — only matches
+  /// distinctive model names (5+ chars) to avoid false positives like
+  /// random text matching "nera", "key", "own", etc.
+  static ({String brand, String model})? matchModelAnyBrand(String text) {
+    final normalized = text.trim();
+    if (normalized.length < 4 || normalized.length > 30) return null;
+    final lower = normalized.toLowerCase();
+
+    for (final entry in _modelPatterns.entries) {
+      final brandKey = entry.key;
+      for (final pattern in entry.value) {
+        // Exact substring: 4+ chars is reliable (catches "moxi" in "moxi2 kiss")
+        if (pattern.length >= 4 && lower.contains(pattern)) {
+          final brandName = _brands[brandKey];
+          if (brandName == null) continue;
+          return (brand: brandName, model: normalized);
+        }
+        // Fuzzy: 5+ chars only to avoid false positives on short words
+        if (pattern.length >= 5 && _levenshtein(lower, pattern) <= 1) {
+          final brandName = _brands[brandKey];
+          if (brandName == null) continue;
+          return (brand: brandName, model: normalized);
+        }
       }
     }
 
@@ -165,6 +203,10 @@ class BrandMatcher {
     ],
     'beltone': [
       'achieve', 'imagine', 'amaze', 'rely',
+    ],
+    'sonic': [
+      'captivate', 'enchant', 'celebrate', 'cheer', 'bliss',
+      'joy', 'charm', 'radiance', 'pep', 'flip',
     ],
   };
 

--- a/recycled_sound/lib/features/scanner/data/colour_classifier.dart
+++ b/recycled_sound/lib/features/scanner/data/colour_classifier.dart
@@ -1,0 +1,249 @@
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui' show Color;
+
+/// A reference colour in the hearing aid palette.
+class HearingAidColour {
+  const HearingAidColour(this.name, this.color);
+
+  final String name;
+  final Color color;
+}
+
+/// Result of classifying a sampled colour against the palette.
+class ColourMatch {
+  const ColourMatch({
+    required this.name,
+    required this.reference,
+    required this.deltaE,
+  });
+
+  final String name;
+  final Color reference;
+
+  /// CIELAB Delta E distance — lower is closer. <10 is a strong match.
+  final double deltaE;
+}
+
+/// Classifies camera frame colours against a hearing aid colour palette.
+///
+/// Uses CIELAB colour space for perceptually uniform distance calculations.
+/// Hearing aid colours are muted, skin-tone-adjacent — RGB Euclidean distance
+/// performs poorly on this palette (confuses Beige/Tan/Champagne).
+class ColourClassifier {
+  ColourClassifier._();
+
+  /// The hearing aid colour palette. Values are approximate and may need
+  /// tuning against real devices.
+  static const palette = <HearingAidColour>[
+    HearingAidColour('Beige', Color(0xFFD4B896)),
+    HearingAidColour('Tan', Color(0xFFC4A882)),
+    HearingAidColour('Silver', Color(0xFFA8A9AD)),
+    HearingAidColour('Black', Color(0xFF2C2C2C)),
+    HearingAidColour('Brown', Color(0xFF7B5B3A)),
+    HearingAidColour('Espresso', Color(0xFF4A3728)),
+    HearingAidColour('Champagne', Color(0xFFE8D5B7)),
+    HearingAidColour('Chestnut', Color(0xFF8B5E3C)),
+    HearingAidColour('Rose Gold', Color(0xFFC9A087)),
+    HearingAidColour('Graphite', Color(0xFF5C5C5C)),
+  ];
+
+  /// Pre-computed Lab values for the palette (lazily initialised).
+  static final List<_Lab> _paletteLab = palette
+      .map((c) => _rgbToLab(_r(c.color), _g(c.color), _b(c.color)))
+      .toList(growable: false);
+
+  /// Sample the dominant colour from the centre region of a BGRA8888 frame.
+  ///
+  /// Samples every [stride]th pixel in the centre 20% of the frame.
+  /// Returns the average colour. Typically completes in <0.1ms.
+  static Color sampleFromBgra8888({
+    required Uint8List bytes,
+    required int width,
+    required int height,
+    required int bytesPerRow,
+    int stride = 4,
+  }) {
+    // Centre 20% crop region
+    final x0 = (width * 0.4).toInt();
+    final y0 = (height * 0.4).toInt();
+    final x1 = (width * 0.6).toInt();
+    final y1 = (height * 0.6).toInt();
+
+    int totalR = 0, totalG = 0, totalB = 0;
+    int count = 0;
+
+    for (var y = y0; y < y1; y += stride) {
+      final rowOffset = y * bytesPerRow;
+      for (var x = x0; x < x1; x += stride) {
+        final i = rowOffset + x * 4;
+        // BGRA8888: B=0, G=1, R=2, A=3
+        totalB += bytes[i];
+        totalG += bytes[i + 1];
+        totalR += bytes[i + 2];
+        count++;
+      }
+    }
+
+    if (count == 0) return const Color(0xFF808080);
+
+    return Color.fromARGB(
+      255,
+      totalR ~/ count,
+      totalG ~/ count,
+      totalB ~/ count,
+    );
+  }
+
+  /// Classify a colour against the hearing aid palette.
+  ///
+  /// Returns the nearest match using CIELAB Delta E distance.
+  static ColourMatch classify(Color sampled) {
+    final lab = _rgbToLab(_r(sampled), _g(sampled), _b(sampled));
+
+    var bestIndex = 0;
+    var bestDist = double.infinity;
+
+    for (var i = 0; i < _paletteLab.length; i++) {
+      final ref = _paletteLab[i];
+      final dL = lab.l - ref.l;
+      final dA = lab.a - ref.a;
+      final dB = lab.b - ref.b;
+      final dist = sqrt(dL * dL + dA * dA + dB * dB);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIndex = i;
+      }
+    }
+
+    return ColourMatch(
+      name: palette[bestIndex].name,
+      reference: palette[bestIndex].color,
+      deltaE: bestDist,
+    );
+  }
+
+  // ── Colour channel helpers (Flutter 3.11+ deprecates .red/.green/.blue) ─
+
+  static int _r(Color c) => (c.r * 255.0).round().clamp(0, 255);
+  static int _g(Color c) => (c.g * 255.0).round().clamp(0, 255);
+  static int _b(Color c) => (c.b * 255.0).round().clamp(0, 255);
+
+  // ── CIELAB conversion ──────────────────────────────────────────────────
+
+  static _Lab _rgbToLab(int r, int g, int b) {
+    // sRGB → linear RGB
+    var lr = _srgbToLinear(r / 255.0);
+    var lg = _srgbToLinear(g / 255.0);
+    var lb = _srgbToLinear(b / 255.0);
+
+    // Linear RGB → XYZ (D65 illuminant)
+    var x = 0.4124564 * lr + 0.3575761 * lg + 0.1804375 * lb;
+    var y = 0.2126729 * lr + 0.7151522 * lg + 0.0721750 * lb;
+    var z = 0.0193339 * lr + 0.1191920 * lg + 0.9503041 * lb;
+
+    // Normalise to D65 white point
+    x /= 0.95047;
+    y /= 1.00000;
+    z /= 1.08883;
+
+    // XYZ → Lab
+    x = _labF(x);
+    y = _labF(y);
+    z = _labF(z);
+
+    return _Lab(
+      l: 116.0 * y - 16.0,
+      a: 500.0 * (x - y),
+      b: 200.0 * (y - z),
+    );
+  }
+
+  static double _srgbToLinear(double c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4).toDouble();
+  }
+
+  static double _labF(double t) {
+    const delta = 6.0 / 29.0;
+    return t > delta * delta * delta
+        ? pow(t, 1.0 / 3.0).toDouble()
+        : t / (3.0 * delta * delta) + 4.0 / 29.0;
+  }
+}
+
+/// Internal CIELAB representation.
+class _Lab {
+  const _Lab({required this.l, required this.a, required this.b});
+  final double l;
+  final double a;
+  final double b;
+}
+
+/// Stabilises colour readings across frames using a voting buffer.
+///
+/// Prevents flicker by requiring [threshold] out of [bufferSize] recent
+/// frames to agree before reporting a stable colour.
+class ColourStabiliser {
+  ColourStabiliser({this.bufferSize = 8, this.threshold = 5});
+
+  final int bufferSize;
+  final int threshold;
+
+  final List<String> _buffer = [];
+  final List<Color> _rgbBuffer = [];
+
+  /// The current leading colour name, or null if buffer is empty.
+  String? get leadingColour => _leading()?.name;
+
+  /// The palette reference colour for the leading reading.
+  Color? get leadingRgb {
+    final name = leadingColour;
+    if (name == null) return null;
+    for (var i = _buffer.length - 1; i >= 0; i--) {
+      if (_buffer[i] == name) return _rgbBuffer[i];
+    }
+    return null;
+  }
+
+  /// How confident we are: count of the leading colour / bufferSize.
+  /// Returns 0.0–1.0.
+  double get confidence {
+    final lead = _leading();
+    if (lead == null) return 0.0;
+    return lead.count / bufferSize;
+  }
+
+  /// Whether the leading colour has reached the consensus threshold.
+  bool get isStable {
+    final lead = _leading();
+    return lead != null && lead.count >= threshold;
+  }
+
+  /// Push a new reading into the buffer.
+  void push(String name, Color rgb) {
+    _buffer.add(name);
+    _rgbBuffer.add(rgb);
+    if (_buffer.length > bufferSize) {
+      _buffer.removeAt(0);
+      _rgbBuffer.removeAt(0);
+    }
+  }
+
+  /// Reset the buffer (e.g. when scanner restarts).
+  void reset() {
+    _buffer.clear();
+    _rgbBuffer.clear();
+  }
+
+  ({String name, int count})? _leading() {
+    if (_buffer.isEmpty) return null;
+    final counts = <String, int>{};
+    for (final name in _buffer) {
+      counts[name] = (counts[name] ?? 0) + 1;
+    }
+    final best = counts.entries.reduce(
+      (a, b) => a.value >= b.value ? a : b,
+    );
+    return (name: best.key, count: best.value);
+  }
+}

--- a/recycled_sound/lib/features/scanner/data/models/scan_result.dart
+++ b/recycled_sound/lib/features/scanner/data/models/scan_result.dart
@@ -1,3 +1,22 @@
+/// Enumeration of all editable spec fields on a scan result.
+///
+/// Used by [ScanResultNotifier.updateField] so the compiler enforces
+/// exhaustive handling — adding a field to [ScanResult] without handling
+/// it in the read/write switches is a compile error, not a silent bug.
+enum ScanField {
+  brand,
+  model,
+  type,
+  year,
+  batterySize,
+  domeType,
+  waxFilter,
+  receiver,
+  colour,
+  tubing,
+  powerSource,
+}
+
 /// Represents a single identified spec field with its confidence score.
 class SpecField {
   const SpecField({required this.value, required this.confidence});
@@ -97,6 +116,36 @@ class ScanResult {
 
   /// Whether all 7 fields are filled.
   bool get isComplete => filledFieldCount == 7;
+
+  /// Read a field by enum. Returns null for optional fields that aren't set.
+  SpecField? fieldFor(ScanField f) => switch (f) {
+        ScanField.brand => brand,
+        ScanField.model => model,
+        ScanField.type => type,
+        ScanField.year => year,
+        ScanField.batterySize => batterySize,
+        ScanField.domeType => domeType,
+        ScanField.waxFilter => waxFilter,
+        ScanField.receiver => receiver,
+        ScanField.colour => colour,
+        ScanField.tubing => tubing,
+        ScanField.powerSource => powerSource,
+      };
+
+  /// Return a copy with one field replaced. Exhaustive — compiler-enforced.
+  ScanResult withField(ScanField f, SpecField value) => switch (f) {
+        ScanField.brand => copyWith(brand: value),
+        ScanField.model => copyWith(model: value),
+        ScanField.type => copyWith(type: value),
+        ScanField.year => copyWith(year: value),
+        ScanField.batterySize => copyWith(batterySize: value),
+        ScanField.domeType => copyWith(domeType: value),
+        ScanField.waxFilter => copyWith(waxFilter: value),
+        ScanField.receiver => copyWith(receiver: value),
+        ScanField.colour => copyWith(colour: value),
+        ScanField.tubing => copyWith(tubing: value),
+        ScanField.powerSource => copyWith(powerSource: value),
+      };
 
   ScanResult copyWith({
     String? scanId,

--- a/recycled_sound/lib/features/scanner/data/models/scan_result.dart
+++ b/recycled_sound/lib/features/scanner/data/models/scan_result.dart
@@ -34,6 +34,8 @@ class ScanResult {
     required this.waxFilter,
     required this.receiver,
     this.colour,
+    this.tubing,
+    this.powerSource,
     this.rawLabels = const [],
   });
 
@@ -41,7 +43,10 @@ class ScanResult {
   final String imageUrl;
   final SpecField brand;
   final SpecField model;
+
+  /// Style/form factor: BTE, RIC, ITE, CIC, ITC, IIC.
   final SpecField type;
+
   final SpecField year;
   final SpecField batterySize;
   final SpecField domeType;
@@ -51,7 +56,47 @@ class ScanResult {
   /// Device colour identified by on-device colour sampling.
   final SpecField? colour;
 
+  /// Tubing type: slim, standard, or none (Seray's field 4).
+  final SpecField? tubing;
+
+  /// Power source: Battery or Rechargeable (Seray's field 5).
+  final SpecField? powerSource;
+
   final List<String> rawLabels;
+
+  /// The 7 fields Seray's audiologist model requires, in order.
+  /// Returns a map of field key → (label, SpecField?, whether AI can fill it).
+  List<({String key, String label, SpecField? field, bool aiAssisted})>
+      get sevenFields => [
+            (key: 'brand', label: 'Make', field: brand, aiAssisted: true),
+            (key: 'model', label: 'Model', field: model, aiAssisted: true),
+            (key: 'type', label: 'Style', field: type, aiAssisted: true),
+            (key: 'tubing', label: 'Tubing', field: tubing, aiAssisted: false),
+            (
+              key: 'powerSource',
+              label: 'Power',
+              field: powerSource,
+              aiAssisted: false,
+            ),
+            (
+              key: 'batterySize',
+              label: 'Battery Size',
+              field: batterySize,
+              aiAssisted: false,
+            ),
+            (key: 'colour', label: 'Colour', field: colour, aiAssisted: true),
+          ];
+
+  /// How many of the 7 fields have a non-empty value.
+  int get filledFieldCount => sevenFields
+      .where((f) =>
+          f.field != null &&
+          f.field!.value.isNotEmpty &&
+          f.field!.value != '—')
+      .length;
+
+  /// Whether all 7 fields are filled.
+  bool get isComplete => filledFieldCount == 7;
 
   ScanResult copyWith({
     String? scanId,
@@ -65,6 +110,8 @@ class ScanResult {
     SpecField? waxFilter,
     SpecField? receiver,
     SpecField? colour,
+    SpecField? tubing,
+    SpecField? powerSource,
     List<String>? rawLabels,
   }) =>
       ScanResult(
@@ -79,6 +126,8 @@ class ScanResult {
         waxFilter: waxFilter ?? this.waxFilter,
         receiver: receiver ?? this.receiver,
         colour: colour ?? this.colour,
+        tubing: tubing ?? this.tubing,
+        powerSource: powerSource ?? this.powerSource,
         rawLabels: rawLabels ?? this.rawLabels,
       );
 
@@ -100,6 +149,12 @@ class ScanResult {
         colour: json['colour'] != null
             ? SpecField.fromJson(json['colour'] as Map<String, dynamic>)
             : null,
+        tubing: json['tubing'] != null
+            ? SpecField.fromJson(json['tubing'] as Map<String, dynamic>)
+            : null,
+        powerSource: json['powerSource'] != null
+            ? SpecField.fromJson(json['powerSource'] as Map<String, dynamic>)
+            : null,
         rawLabels: (json['rawLabels'] as List<dynamic>?)
                 ?.map((e) => e as String)
                 .toList() ??
@@ -107,18 +162,22 @@ class ScanResult {
       );
 
   /// Returns a mock result for development/testing.
+  ///
+  /// Simulates a real scan: brand, model, and colour are AI-filled.
+  /// Style is pre-populated from CLIP probe (91.2%). Tubing, power source,
+  /// and battery size are left for the audiologist.
   factory ScanResult.mock() => const ScanResult(
         scanId: 'mock-001',
         imageUrl: '',
         brand: SpecField(value: 'Phonak', confidence: 95),
         model: SpecField(value: 'Audéo P90', confidence: 88),
-        type: SpecField(value: 'RIC (Receiver-in-Canal)', confidence: 92),
+        type: SpecField(value: 'RIC', confidence: 91),
         year: SpecField(value: '2021', confidence: 75),
-        batterySize: SpecField(value: 'Size 312', confidence: 80),
+        batterySize: SpecField(value: '', confidence: 0),
         domeType: SpecField(value: 'Closed', confidence: 70),
         waxFilter: SpecField(value: 'CeruShield Disk', confidence: 65),
         receiver: SpecField(value: 'M receiver', confidence: 72),
-        colour: SpecField(value: 'Champagne', confidence: 70),
+        colour: SpecField(value: 'Champagne', confidence: 85),
         rawLabels: ['hearing aid', 'Phonak', 'behind-the-ear', 'medical device'],
       );
 }

--- a/recycled_sound/lib/features/scanner/data/models/scan_result.dart
+++ b/recycled_sound/lib/features/scanner/data/models/scan_result.dart
@@ -180,6 +180,23 @@ class ScanResult {
         rawLabels: rawLabels ?? this.rawLabels,
       );
 
+  Map<String, dynamic> toJson() => {
+        'scanId': scanId,
+        'imageUrl': imageUrl,
+        'brand': brand.toJson(),
+        'model': model.toJson(),
+        'type': type.toJson(),
+        'year': year.toJson(),
+        'batterySize': batterySize.toJson(),
+        'domeType': domeType.toJson(),
+        'waxFilter': waxFilter.toJson(),
+        'receiver': receiver.toJson(),
+        if (colour != null) 'colour': colour!.toJson(),
+        if (tubing != null) 'tubing': tubing!.toJson(),
+        if (powerSource != null) 'powerSource': powerSource!.toJson(),
+        'rawLabels': rawLabels,
+      };
+
   factory ScanResult.fromJson(Map<String, dynamic> json) => ScanResult(
         scanId: json['scanId'] as String,
         imageUrl: json['imageUrl'] as String,

--- a/recycled_sound/lib/features/scanner/data/models/scan_result.dart
+++ b/recycled_sound/lib/features/scanner/data/models/scan_result.dart
@@ -33,6 +33,7 @@ class ScanResult {
     required this.domeType,
     required this.waxFilter,
     required this.receiver,
+    this.colour,
     this.rawLabels = const [],
   });
 
@@ -46,6 +47,10 @@ class ScanResult {
   final SpecField domeType;
   final SpecField waxFilter;
   final SpecField receiver;
+
+  /// Device colour identified by on-device colour sampling.
+  final SpecField? colour;
+
   final List<String> rawLabels;
 
   ScanResult copyWith({
@@ -59,6 +64,7 @@ class ScanResult {
     SpecField? domeType,
     SpecField? waxFilter,
     SpecField? receiver,
+    SpecField? colour,
     List<String>? rawLabels,
   }) =>
       ScanResult(
@@ -72,6 +78,7 @@ class ScanResult {
         domeType: domeType ?? this.domeType,
         waxFilter: waxFilter ?? this.waxFilter,
         receiver: receiver ?? this.receiver,
+        colour: colour ?? this.colour,
         rawLabels: rawLabels ?? this.rawLabels,
       );
 
@@ -90,6 +97,9 @@ class ScanResult {
             SpecField.fromJson(json['waxFilter'] as Map<String, dynamic>),
         receiver:
             SpecField.fromJson(json['receiver'] as Map<String, dynamic>),
+        colour: json['colour'] != null
+            ? SpecField.fromJson(json['colour'] as Map<String, dynamic>)
+            : null,
         rawLabels: (json['rawLabels'] as List<dynamic>?)
                 ?.map((e) => e as String)
                 .toList() ??
@@ -108,6 +118,7 @@ class ScanResult {
         domeType: SpecField(value: 'Closed', confidence: 70),
         waxFilter: SpecField(value: 'CeruShield Disk', confidence: 65),
         receiver: SpecField(value: 'M receiver', confidence: 72),
+        colour: SpecField(value: 'Champagne', confidence: 70),
         rawLabels: ['hearing aid', 'Phonak', 'behind-the-ear', 'medical device'],
       );
 }

--- a/recycled_sound/lib/features/scanner/presentation/analysing_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/analysing_screen.dart
@@ -76,7 +76,7 @@ class _AnalysingScreenState extends ConsumerState<AnalysingScreen>
 
       // Set the real result in the provider
       ref.read(scanResultProvider.notifier).setResult(result);
-      context.pushReplacement('/scan/results', extra: result.scanId);
+      context.pushReplacement('/scan/confirm');
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e.toString());

--- a/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
@@ -99,7 +99,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSave: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('brand', v),
+                        .updateField(ScanField.brand, v),
                   ),
 
                   // 2. MODEL — AI-filled, tap to correct
@@ -109,7 +109,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSave: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('model', v),
+                        .updateField(ScanField.model, v),
                   ),
 
                   // 3. STYLE — chip selector (CLIP probe @ 91.2%)
@@ -128,7 +128,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     aiConfidence: result.type.confidence,
                     onSelect: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('type', v),
+                        .updateField(ScanField.type, v),
                   ),
 
                   // 4. TUBING — chip selector (human only)
@@ -139,7 +139,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSelect: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('tubing', v),
+                        .updateField(ScanField.tubing, v),
                   ),
 
                   // 5. POWER — toggle (battery vs rechargeable)
@@ -150,7 +150,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSelect: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('powerSource', v),
+                        .updateField(ScanField.powerSource, v),
                   ),
 
                   // 6. BATTERY SIZE — chip selector (4 classes)
@@ -161,7 +161,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSelect: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('batterySize', v),
+                        .updateField(ScanField.batterySize, v),
                     enabled: result.powerSource?.value != 'Rechargeable',
                   ),
 
@@ -174,7 +174,7 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     pulseController: _pulseController,
                     onSelect: (v) => ref
                         .read(scanResultProvider.notifier)
-                        .updateField('colour', v),
+                        .updateField(ScanField.colour, v),
                   ),
                 ],
               ),

--- a/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_typography.dart';
 import '../data/brand_colour_palettes.dart';
 import '../data/colour_classifier.dart';
 import '../data/models/scan_result.dart';
@@ -58,6 +59,10 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
       _completionFired = true;
       HapticFeedback.heavyImpact();
       _completionController.forward();
+    } else if (!result.isComplete && _completionFired) {
+      // User un-filled a field — reset so the ceremony can fire again.
+      _completionFired = false;
+      _completionController.reset();
     }
   }
 
@@ -148,9 +153,16 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
                     field: result.powerSource,
                     options: const ['Battery', 'Rechargeable'],
                     pulseController: _pulseController,
-                    onSelect: (v) => ref
-                        .read(scanResultProvider.notifier)
-                        .updateField(ScanField.powerSource, v),
+                    onSelect: (v) {
+                      final notifier =
+                          ref.read(scanResultProvider.notifier);
+                      notifier.updateField(ScanField.powerSource, v);
+                      // Clear battery size when switching to rechargeable,
+                      // set N/A so the field counts as filled.
+                      if (v == 'Rechargeable') {
+                        notifier.updateField(ScanField.batterySize, 'N/A');
+                      }
+                    },
                   ),
 
                   // 6. BATTERY SIZE — chip selector (4 classes)
@@ -202,12 +214,10 @@ class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
     );
   }
 
-  /// If power source is "Rechargeable", override battery size display.
+  /// Battery size field — null if empty (triggers amber pulse).
   SpecField? _batteryDisplayField(ScanResult result) {
-    if (result.powerSource?.value == 'Rechargeable') {
-      return const SpecField(value: 'N/A', confidence: 100);
-    }
-    return result.batterySize.value.isEmpty ? null : result.batterySize;
+    final bs = result.batterySize;
+    return bs.value.isEmpty ? null : bs;
   }
 }
 
@@ -288,11 +298,7 @@ class _HeaderStrip extends StatelessWidget {
               // Counter text
               Text(
                 isComplete ? 'IDENTIFICATION COMPLETE' : '$filled OF $total',
-                style: TextStyle(
-                  fontFamily: 'monospace',
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 1.2,
+                style: AppTypography.monoStatus.copyWith(
                   color: isComplete
                       ? AppColors.success
                       : const Color(0xFF888888),
@@ -464,14 +470,12 @@ class _ChipSelectorField extends StatelessWidget {
                   child: _ConfidenceBadge(confidence: aiConfidence!),
                 ),
               if (!enabled)
-                const Padding(
-                  padding: EdgeInsets.only(left: 8),
+              Padding(
+                  padding: const EdgeInsets.only(left: 8),
                   child: Text(
                     'N/A',
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 11,
-                      color: Color(0xFF555555),
+                    style: AppTypography.monoStatus.copyWith(
+                      color: const Color(0xFF555555),
                     ),
                   ),
                 ),
@@ -514,9 +518,7 @@ class _ChipSelectorField extends StatelessWidget {
                   ),
                   child: Text(
                     option,
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 13,
+                    style: AppTypography.monoValue.copyWith(
                       fontWeight:
                           isSelected ? FontWeight.w600 : FontWeight.w400,
                       color: isSelected
@@ -524,7 +526,6 @@ class _ChipSelectorField extends StatelessWidget {
                           : enabled
                               ? const Color(0xFFAAAAAA)
                               : const Color(0xFF555555),
-                      letterSpacing: 0.3,
                     ),
                   ),
                 ),
@@ -593,12 +594,8 @@ class _ColourSwatchField extends StatelessWidget {
                   ),
                   child: Text(
                     'BRAND PALETTE',
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 8,
-                      fontWeight: FontWeight.w600,
+                    style: AppTypography.monoMicro.copyWith(
                       color: AppColors.primary.withValues(alpha: 0.8),
-                      letterSpacing: 0.8,
                     ),
                   ),
                 ),
@@ -655,9 +652,7 @@ class _ColourSwatchField extends StatelessWidget {
                         textAlign: TextAlign.center,
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontFamily: 'monospace',
-                          fontSize: 8,
+                        style: AppTypography.monoMicro.copyWith(
                           fontWeight: isSelected
                               ? FontWeight.w600
                               : FontWeight.w400,
@@ -729,13 +724,9 @@ class _BottomAction extends StatelessWidget {
                       borderRadius: BorderRadius.circular(10),
                     ),
                   ),
-                  child: const Text(
+                  child: Text(
                     'Scan Another',
-                    style: TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
-                    ),
+                    style: AppTypography.monoButton,
                   ),
                 ),
               ),
@@ -767,11 +758,7 @@ class _BottomAction extends StatelessWidget {
                     ),
                     label: Text(
                       isComplete ? 'Add to Register' : 'Complete All Fields',
-                      style: const TextStyle(
-                        fontFamily: 'monospace',
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                      ),
+                      style: AppTypography.monoValue,
                     ),
                     style: FilledButton.styleFrom(
                       backgroundColor: isComplete
@@ -823,28 +810,39 @@ class _FieldContainer extends StatelessWidget {
       animation: pulseController,
       builder: (context, child) {
         final pulseAlpha = hasFill ? 0.0 : 0.15 + 0.15 * pulseController.value;
-        return Container(
-          margin: const EdgeInsets.only(bottom: 2),
-          decoration: BoxDecoration(
-            color: hasFill
-                ? const Color(0xFF151515)
-                : Color.lerp(
-                    const Color(0xFF151515),
-                    _amberColor.withValues(alpha: 0.05),
-                    pulseController.value,
-                  ),
+        final accentColor = hasFill
+            ? _greenColor.withValues(alpha: 0.6)
+            : _amberColor.withValues(alpha: pulseAlpha + 0.2);
+        final bgColor = hasFill
+            ? const Color(0xFF151515)
+            : Color.lerp(
+                const Color(0xFF151515),
+                _amberColor.withValues(alpha: 0.05),
+                pulseController.value,
+              )!;
+
+        // Use a Row with a coloured strip instead of Border(left:) + borderRadius,
+        // which Flutter doesn't officially support together.
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 2),
+          child: ClipRRect(
             borderRadius: BorderRadius.circular(12),
-            border: Border(
-              left: BorderSide(
-                color: hasFill
-                    ? _greenColor.withValues(alpha: 0.6)
-                    : _amberColor.withValues(alpha: pulseAlpha + 0.2),
-                width: 3,
+            child: Container(
+              color: bgColor,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Container(width: 3, color: accentColor),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(14),
+                      child: child!,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
-          padding: const EdgeInsets.all(14),
-          child: child!,
         );
       },
       child: child,
@@ -861,16 +859,7 @@ class _FieldLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: 72,
-      child: Text(
-        label,
-        style: const TextStyle(
-          fontFamily: 'monospace',
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-          color: Color(0xFF888888),
-          letterSpacing: 1.0,
-        ),
-      ),
+      child: Text(label, style: AppTypography.monoLabel),
     );
   }
 }
@@ -901,12 +890,8 @@ class _ConfidenceBadge extends StatelessWidget {
       ),
       child: Text(
         '$label $confidence%',
-        style: TextStyle(
-          fontFamily: 'monospace',
-          fontSize: 9,
-          fontWeight: FontWeight.w600,
+        style: AppTypography.monoSmall.copyWith(
           color: color.withValues(alpha: 0.9),
-          letterSpacing: 0.5,
         ),
       ),
     );
@@ -942,10 +927,7 @@ class _ActionButton extends StatelessWidget {
   }
 }
 
-TextStyle _valueStyle(bool hasFill) => TextStyle(
-      fontFamily: 'monospace',
-      fontSize: 15,
+TextStyle _valueStyle(bool hasFill) => AppTypography.monoValueLarge.copyWith(
       fontWeight: hasFill ? FontWeight.w600 : FontWeight.w400,
       color: hasFill ? Colors.white : const Color(0xFF555555),
-      letterSpacing: 0.3,
     );

--- a/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/confirmation_screen.dart
@@ -1,0 +1,951 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/theme/app_colors.dart';
+import '../data/brand_colour_palettes.dart';
+import '../data/colour_classifier.dart';
+import '../data/models/scan_result.dart';
+import '../providers/scanner_providers.dart';
+
+/// The 7-field confirmation screen — where AI meets audiologist.
+///
+/// This screen is the convergence point for every signal upstream (neural net,
+/// OCR, CIELAB colour, CLIP style probe) and the gateway to everything
+/// downstream (device register, matching, redistribution).
+///
+/// Design language: dark background carrying the T2 HUD aesthetic forward.
+/// Green = AI confident. Amber = needs attention. Pulse = "I still need this."
+/// Not a form — a conversation the scanner had with the device, presented
+/// for the audiologist to confirm or correct.
+class ConfirmationScreen extends ConsumerStatefulWidget {
+  const ConfirmationScreen({super.key});
+
+  @override
+  ConsumerState<ConfirmationScreen> createState() => _ConfirmationScreenState();
+}
+
+class _ConfirmationScreenState extends ConsumerState<ConfirmationScreen>
+    with TickerProviderStateMixin {
+  late final AnimationController _pulseController;
+  late final AnimationController _completionController;
+  bool _completionFired = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1800),
+    )..repeat(reverse: true);
+
+    _completionController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    _completionController.dispose();
+    super.dispose();
+  }
+
+  void _checkCompletion(ScanResult result) {
+    if (result.isComplete && !_completionFired) {
+      _completionFired = true;
+      HapticFeedback.heavyImpact();
+      _completionController.forward();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = ref.watch(scanResultProvider);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkCompletion(result);
+    });
+
+    final filled = result.filledFieldCount;
+    final brandPalette = result.brand.value.isNotEmpty
+        ? BrandColourPalettes.forBrand(result.brand.value)
+        : null;
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0D0D),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // ── Header strip ──────────────────────────────────────────
+            _HeaderStrip(
+              filled: filled,
+              total: 7,
+              isComplete: result.isComplete,
+              completionAnimation: _completionController,
+              onClose: () => context.go('/'),
+            ),
+
+            // ── Field list ────────────────────────────────────────────
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                children: [
+                  // 1. MAKE — AI-filled, tap to correct
+                  _AiTextField(
+                    label: 'MAKE',
+                    field: result.brand,
+                    pulseController: _pulseController,
+                    onSave: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('brand', v),
+                  ),
+
+                  // 2. MODEL — AI-filled, tap to correct
+                  _AiTextField(
+                    label: 'MODEL',
+                    field: result.model,
+                    pulseController: _pulseController,
+                    onSave: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('model', v),
+                  ),
+
+                  // 3. STYLE — chip selector (CLIP probe @ 91.2%)
+                  _ChipSelectorField(
+                    label: 'STYLE',
+                    field: result.type,
+                    options: const [
+                      'BTE',
+                      'RIC',
+                      'ITE',
+                      'ITC',
+                      'CIC',
+                      'IIC',
+                    ],
+                    pulseController: _pulseController,
+                    aiConfidence: result.type.confidence,
+                    onSelect: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('type', v),
+                  ),
+
+                  // 4. TUBING — chip selector (human only)
+                  _ChipSelectorField(
+                    label: 'TUBING',
+                    field: result.tubing,
+                    options: const ['Slim', 'Standard', 'None'],
+                    pulseController: _pulseController,
+                    onSelect: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('tubing', v),
+                  ),
+
+                  // 5. POWER — toggle (battery vs rechargeable)
+                  _ChipSelectorField(
+                    label: 'POWER',
+                    field: result.powerSource,
+                    options: const ['Battery', 'Rechargeable'],
+                    pulseController: _pulseController,
+                    onSelect: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('powerSource', v),
+                  ),
+
+                  // 6. BATTERY SIZE — chip selector (4 classes)
+                  _ChipSelectorField(
+                    label: 'BATTERY',
+                    field: _batteryDisplayField(result),
+                    options: const ['10', '13', '312', '675', 'N/A'],
+                    pulseController: _pulseController,
+                    onSelect: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('batterySize', v),
+                    enabled: result.powerSource?.value != 'Rechargeable',
+                  ),
+
+                  // 7. COLOUR — brand-specific swatches
+                  _ColourSwatchField(
+                    label: 'COLOUR',
+                    field: result.colour,
+                    brandPalette: brandPalette,
+                    genericPalette: ColourClassifier.palette,
+                    pulseController: _pulseController,
+                    onSelect: (v) => ref
+                        .read(scanResultProvider.notifier)
+                        .updateField('colour', v),
+                  ),
+                ],
+              ),
+            ),
+
+            // ── Bottom action ─────────────────────────────────────────
+            _BottomAction(
+              isComplete: result.isComplete,
+              completionAnimation: _completionController,
+              onConfirm: () {
+                HapticFeedback.mediumImpact();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Device added to register (pending QA)'),
+                    backgroundColor: AppColors.success,
+                  ),
+                );
+                context.go('/devices');
+              },
+              onScanAnother: () => context.pushReplacement('/scan'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// If power source is "Rechargeable", override battery size display.
+  SpecField? _batteryDisplayField(ScanResult result) {
+    if (result.powerSource?.value == 'Rechargeable') {
+      return const SpecField(value: 'N/A', confidence: 100);
+    }
+    return result.batterySize.value.isEmpty ? null : result.batterySize;
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Header Strip — progress counter + completion flash
+// ═══════════════════════════════════════════════════════════════════════════
+
+class _HeaderStrip extends StatelessWidget {
+  const _HeaderStrip({
+    required this.filled,
+    required this.total,
+    required this.isComplete,
+    required this.completionAnimation,
+    required this.onClose,
+  });
+
+  final int filled;
+  final int total;
+  final bool isComplete;
+  final AnimationController completionAnimation;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: completionAnimation,
+      builder: (context, child) {
+        final glow = completionAnimation.value;
+        return Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          decoration: BoxDecoration(
+            color: Color.lerp(
+              const Color(0xFF1A1A1A),
+              AppColors.success.withValues(alpha: 0.15),
+              glow,
+            ),
+            border: Border(
+              bottom: BorderSide(
+                color: isComplete
+                    ? AppColors.success.withValues(alpha: 0.3 + 0.4 * glow)
+                    : const Color(0xFF333333),
+                width: 1,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              // Progress dots
+              ...List.generate(total, (i) {
+                final isFilled = i < filled;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 6),
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 300),
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isFilled
+                          ? AppColors.success
+                          : const Color(0xFF444444),
+                      boxShadow: isFilled && isComplete
+                          ? [
+                              BoxShadow(
+                                color:
+                                    AppColors.success.withValues(alpha: 0.5),
+                                blurRadius: 4 + 4 * glow,
+                              ),
+                            ]
+                          : null,
+                    ),
+                  ),
+                );
+              }),
+
+              const SizedBox(width: 12),
+
+              // Counter text
+              Text(
+                isComplete ? 'IDENTIFICATION COMPLETE' : '$filled OF $total',
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.2,
+                  color: isComplete
+                      ? AppColors.success
+                      : const Color(0xFF888888),
+                ),
+              ),
+
+              const Spacer(),
+
+              // Close
+              IconButton(
+                icon: const Icon(Icons.close, color: Color(0xFF888888)),
+                iconSize: 20,
+                onPressed: onClose,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AI Text Field — for Make & Model (tap to edit free text)
+// ═══════════════════════════════════════════════════════════════════════════
+
+class _AiTextField extends StatefulWidget {
+  const _AiTextField({
+    required this.label,
+    required this.field,
+    required this.pulseController,
+    required this.onSave,
+  });
+
+  final String label;
+  final SpecField field;
+  final AnimationController pulseController;
+  final ValueChanged<String> onSave;
+
+  @override
+  State<_AiTextField> createState() => _AiTextFieldState();
+}
+
+class _AiTextFieldState extends State<_AiTextField> {
+  bool _editing = false;
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.field.value);
+  }
+
+  @override
+  void didUpdateWidget(_AiTextField old) {
+    super.didUpdateWidget(old);
+    if (old.field.value != widget.field.value && !_editing) {
+      _controller.text = widget.field.value;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final v = _controller.text.trim();
+    if (v.isNotEmpty && v != widget.field.value) {
+      HapticFeedback.lightImpact();
+      widget.onSave(v);
+    }
+    setState(() => _editing = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasFill = widget.field.value.isNotEmpty;
+    final confidence = widget.field.confidence;
+
+    return _FieldContainer(
+      hasFill: hasFill,
+      pulseController: widget.pulseController,
+      child: Row(
+        children: [
+          _FieldLabel(label: widget.label),
+          if (_editing) ...[
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                autofocus: true,
+                style: _valueStyle(true),
+                cursorColor: AppColors.success,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  border: InputBorder.none,
+                  contentPadding: EdgeInsets.symmetric(vertical: 4),
+                ),
+                onSubmitted: (_) => _save(),
+              ),
+            ),
+            _ActionButton(
+              icon: Icons.check,
+              color: AppColors.success,
+              onTap: _save,
+            ),
+          ] else ...[
+            Expanded(
+              child: Text(
+                hasFill ? widget.field.value : '— tap to enter —',
+                style: _valueStyle(hasFill),
+              ),
+            ),
+            if (hasFill) _ConfidenceBadge(confidence: confidence),
+            const SizedBox(width: 8),
+            _ActionButton(
+              icon: hasFill ? Icons.edit_outlined : Icons.add,
+              color: hasFill ? const Color(0xFF666666) : _amberColor,
+              onTap: () => setState(() => _editing = true),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Chip Selector Field — for Style, Tubing, Power, Battery Size
+// ═══════════════════════════════════════════════════════════════════════════
+
+class _ChipSelectorField extends StatelessWidget {
+  const _ChipSelectorField({
+    required this.label,
+    required this.field,
+    required this.options,
+    required this.pulseController,
+    required this.onSelect,
+    this.aiConfidence,
+    this.enabled = true,
+  });
+
+  final String label;
+  final SpecField? field;
+  final List<String> options;
+  final AnimationController pulseController;
+  final ValueChanged<String> onSelect;
+  final int? aiConfidence;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final current = field?.value ?? '';
+    final hasFill = current.isNotEmpty && current != '—';
+
+    return _FieldContainer(
+      hasFill: hasFill,
+      pulseController: pulseController,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              _FieldLabel(label: label),
+              if (hasFill && aiConfidence != null && aiConfidence! > 0)
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: _ConfidenceBadge(confidence: aiConfidence!),
+                ),
+              if (!enabled)
+                const Padding(
+                  padding: EdgeInsets.only(left: 8),
+                  child: Text(
+                    'N/A',
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 11,
+                      color: Color(0xFF555555),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: options.map((option) {
+              final isSelected = current == option;
+              return GestureDetector(
+                onTap: enabled
+                    ? () {
+                        HapticFeedback.selectionClick();
+                        onSelect(option);
+                      }
+                    : null,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? AppColors.success.withValues(alpha: 0.15)
+                        : enabled
+                            ? const Color(0xFF222222)
+                            : const Color(0xFF1A1A1A),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(
+                      color: isSelected
+                          ? AppColors.success.withValues(alpha: 0.6)
+                          : enabled
+                              ? const Color(0xFF444444)
+                              : const Color(0xFF333333),
+                      width: isSelected ? 1.5 : 1,
+                    ),
+                  ),
+                  child: Text(
+                    option,
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      fontWeight:
+                          isSelected ? FontWeight.w600 : FontWeight.w400,
+                      color: isSelected
+                          ? AppColors.success
+                          : enabled
+                              ? const Color(0xFFAAAAAA)
+                              : const Color(0xFF555555),
+                      letterSpacing: 0.3,
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Colour Swatch Field — brand-specific or generic palette
+// ═══════════════════════════════════════════════════════════════════════════
+
+class _ColourSwatchField extends StatelessWidget {
+  const _ColourSwatchField({
+    required this.label,
+    required this.field,
+    required this.brandPalette,
+    required this.genericPalette,
+    required this.pulseController,
+    required this.onSelect,
+  });
+
+  final String label;
+  final SpecField? field;
+  final List<BrandColour>? brandPalette;
+  final List<HearingAidColour> genericPalette;
+  final AnimationController pulseController;
+  final ValueChanged<String> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final current = field?.value ?? '';
+    final hasFill = current.isNotEmpty;
+
+    // Use brand palette if available, otherwise generic
+    final swatches = brandPalette ??
+        genericPalette
+            .map((c) => BrandColour(c.name, c.color))
+            .toList();
+
+    return _FieldContainer(
+      hasFill: hasFill,
+      pulseController: pulseController,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              _FieldLabel(label: label),
+              if (hasFill) ...[
+                const SizedBox(width: 8),
+                _ConfidenceBadge(confidence: field!.confidence),
+              ],
+              if (brandPalette != null) ...[
+                const Spacer(),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(4),
+                    color: AppColors.primary.withValues(alpha: 0.15),
+                  ),
+                  child: Text(
+                    'BRAND PALETTE',
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 8,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.primary.withValues(alpha: 0.8),
+                      letterSpacing: 0.8,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: swatches.map((swatch) {
+              final isSelected = current == swatch.name;
+              return GestureDetector(
+                onTap: () {
+                  HapticFeedback.selectionClick();
+                  onSelect(swatch.name);
+                },
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: swatch.color,
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(
+                          color: isSelected
+                              ? AppColors.success
+                              : const Color(0xFF555555),
+                          width: isSelected ? 2.5 : 1,
+                        ),
+                        boxShadow: isSelected
+                            ? [
+                                BoxShadow(
+                                  color:
+                                      AppColors.success.withValues(alpha: 0.3),
+                                  blurRadius: 8,
+                                ),
+                              ]
+                            : null,
+                      ),
+                      child: isSelected
+                          ? const Icon(Icons.check,
+                              size: 18, color: Colors.white)
+                          : null,
+                    ),
+                    const SizedBox(height: 4),
+                    SizedBox(
+                      width: 52,
+                      child: Text(
+                        swatch.name,
+                        textAlign: TextAlign.center,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 8,
+                          fontWeight: isSelected
+                              ? FontWeight.w600
+                              : FontWeight.w400,
+                          color: isSelected
+                              ? AppColors.success
+                              : const Color(0xFF888888),
+                          height: 1.2,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Bottom Action Bar
+// ═══════════════════════════════════════════════════════════════════════════
+
+class _BottomAction extends StatelessWidget {
+  const _BottomAction({
+    required this.isComplete,
+    required this.completionAnimation,
+    required this.onConfirm,
+    required this.onScanAnother,
+  });
+
+  final bool isComplete;
+  final AnimationController completionAnimation;
+  final VoidCallback onConfirm;
+  final VoidCallback onScanAnother;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: completionAnimation,
+      builder: (context, child) {
+        final glow = completionAnimation.value;
+        return Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+          decoration: BoxDecoration(
+            color: const Color(0xFF1A1A1A),
+            border: Border(
+              top: BorderSide(
+                color: isComplete
+                    ? AppColors.success.withValues(alpha: 0.3 + 0.4 * glow)
+                    : const Color(0xFF333333),
+                width: 1,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              // Scan Another (always available)
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onScanAnother,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF888888),
+                    side: const BorderSide(color: Color(0xFF444444)),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: const Text(
+                    'Scan Another',
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(width: 12),
+
+              // Add to Register (enabled when complete)
+              Expanded(
+                flex: 2,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 300),
+                  decoration: isComplete
+                      ? BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          boxShadow: [
+                            BoxShadow(
+                              color:
+                                  AppColors.success.withValues(alpha: 0.3 * glow),
+                              blurRadius: 12,
+                            ),
+                          ],
+                        )
+                      : null,
+                  child: FilledButton.icon(
+                    onPressed: isComplete ? onConfirm : null,
+                    icon: Icon(
+                      isComplete ? Icons.check_circle : Icons.pending,
+                      size: 18,
+                    ),
+                    label: Text(
+                      isComplete ? 'Add to Register' : 'Complete All Fields',
+                      style: const TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: isComplete
+                          ? AppColors.success
+                          : const Color(0xFF333333),
+                      foregroundColor: isComplete
+                          ? Colors.white
+                          : const Color(0xFF666666),
+                      disabledBackgroundColor: const Color(0xFF333333),
+                      disabledForegroundColor: const Color(0xFF666666),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Shared primitives
+// ═══════════════════════════════════════════════════════════════════════════
+
+const _amberColor = Color(0xFFD4A026);
+const _greenColor = AppColors.success;
+
+/// Container for each field row — handles the left accent bar and pulse.
+class _FieldContainer extends StatelessWidget {
+  const _FieldContainer({
+    required this.hasFill,
+    required this.pulseController,
+    required this.child,
+  });
+
+  final bool hasFill;
+  final AnimationController pulseController;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: pulseController,
+      builder: (context, child) {
+        final pulseAlpha = hasFill ? 0.0 : 0.15 + 0.15 * pulseController.value;
+        return Container(
+          margin: const EdgeInsets.only(bottom: 2),
+          decoration: BoxDecoration(
+            color: hasFill
+                ? const Color(0xFF151515)
+                : Color.lerp(
+                    const Color(0xFF151515),
+                    _amberColor.withValues(alpha: 0.05),
+                    pulseController.value,
+                  ),
+            borderRadius: BorderRadius.circular(12),
+            border: Border(
+              left: BorderSide(
+                color: hasFill
+                    ? _greenColor.withValues(alpha: 0.6)
+                    : _amberColor.withValues(alpha: pulseAlpha + 0.2),
+                width: 3,
+              ),
+            ),
+          ),
+          padding: const EdgeInsets.all(14),
+          child: child!,
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+/// Monospace field label.
+class _FieldLabel extends StatelessWidget {
+  const _FieldLabel({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 72,
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: Color(0xFF888888),
+          letterSpacing: 1.0,
+        ),
+      ),
+    );
+  }
+}
+
+/// Confidence badge — green/amber/red based on percentage.
+class _ConfidenceBadge extends StatelessWidget {
+  const _ConfidenceBadge({required this.confidence});
+  final int confidence;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = confidence >= 90
+        ? _greenColor
+        : confidence >= 70
+            ? _amberColor
+            : AppColors.error;
+    final label = confidence >= 90
+        ? 'HIGH'
+        : confidence >= 70
+            ? 'MED'
+            : 'LOW';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(3),
+        color: color.withValues(alpha: 0.15),
+      ),
+      child: Text(
+        '$label $confidence%',
+        style: TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 9,
+          fontWeight: FontWeight.w600,
+          color: color.withValues(alpha: 0.9),
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+/// Small icon button used for edit/add/confirm actions.
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(6),
+          color: color.withValues(alpha: 0.1),
+        ),
+        child: Icon(icon, size: 16, color: color),
+      ),
+    );
+  }
+}
+
+TextStyle _valueStyle(bool hasFill) => TextStyle(
+      fontFamily: 'monospace',
+      fontSize: 15,
+      fontWeight: hasFill ? FontWeight.w600 : FontWeight.w400,
+      color: hasFill ? Colors.white : const Color(0xFF555555),
+      letterSpacing: 0.3,
+    );

--- a/recycled_sound/lib/features/scanner/presentation/live_scanner_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/live_scanner_screen.dart
@@ -13,7 +13,9 @@ import '../../../core/theme/app_typography.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 
+import '../data/brand_classifier.dart';
 import '../data/brand_matcher.dart';
+import '../data/colour_classifier.dart';
 import 'widgets/capture_stack.dart';
 import 'widgets/feature_overlay_painter.dart';
 import 'widgets/progress_rail.dart';
@@ -47,6 +49,9 @@ class _LiveScanScreenState extends State<LiveScanScreen>
   final _textRecognizer = TextRecognizer();
   bool _isProcessing = false;
 
+  // ── On-device brand classifier (EfficientNet-B0, TFLite) ────────────
+  final _brandClassifier = BrandClassifier();
+
   // ── Detection state ───────────────────────────────────────────────────
   String? _detectedBrand;
   String? _detectedModel;
@@ -67,6 +72,13 @@ class _LiveScanScreenState extends State<LiveScanScreen>
   // ── Completion overlay ────────────────────────────────────────────────
   bool _showCompletion = false;
   bool _completionFired = false;
+
+  // ── Colour detection ─────────────────────────────────────────────────
+  String? _detectedColour;
+  Color? _detectedColourRgb;
+  double _colourConfidence = 0.0;
+  bool _colourConfirmed = false;
+  final ColourStabiliser _colourStabiliser = ColourStabiliser();
 
   // ── Captures & upload ──────────────────────────────────────────────
   final List<CapturedFeature> _captures = [];
@@ -98,6 +110,11 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
     _runBootSequence();
     _initCamera();
+    // Pre-load model during boot sequence — catch errors so it doesn't
+    // crash the app if the TFLite runtime is incompatible
+    _brandClassifier.load().catchError((e) {
+      debugPrint('SCANNER: brand classifier failed to load: $e');
+    });
 
     _hintTimer = Timer(const Duration(seconds: 15), () {
       if (_detectedBrand == null && mounted) {
@@ -115,6 +132,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
     _pulseController.dispose();
     _stopCamera();
     _textRecognizer.close();
+    _brandClassifier.dispose();
     super.dispose();
   }
 
@@ -158,10 +176,30 @@ class _LiveScanScreenState extends State<LiveScanScreen>
       if (cameras.isEmpty) throw Exception('No cameras available');
       if (_disposed) return;
 
+      // Log all available cameras to find the ultra-wide (macro-capable)
+      for (final cam in cameras) {
+        debugPrint('SCANNER: camera: ${cam.name}, '
+            'direction=${cam.lensDirection}, '
+            'sensor=${cam.sensorOrientation}');
+      }
+
+      // On iPhone 13 Pro+, the ultra-wide back camera supports macro (2cm focus).
+      // The main wide camera can't focus closer than ~15cm.
+      // Try to find the ultra-wide (typically the second back-facing camera).
+      final backCameras = cameras
+          .where((c) => c.lensDirection == CameraLensDirection.back)
+          .toList();
+      debugPrint('SCANNER: ${backCameras.length} back cameras found');
+
+      // Use the main wide camera for live preview.
+      // The neural net doesn't need macro focus — it identifies brands
+      // from visual appearance at normal viewing distance.
+      // cameras.first is the default back camera (main wide lens).
       _camera = cameras.first;
+      debugPrint('SCANNER: selected camera: ${_camera!.name}');
       _cameraController = CameraController(
         _camera!,
-        ResolutionPreset.medium,
+        ResolutionPreset.high,
         enableAudio: false,
         imageFormatGroup: Platform.isIOS
             ? ImageFormatGroup.bgra8888
@@ -170,6 +208,16 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
       await _cameraController!.initialize();
       if (_disposed) return;
+
+      // Enable continuous autofocus with centre focus point.
+      // setFocusPoint tells the camera to prioritise the centre of frame,
+      // which helps it lock focus on the hearing aid.
+      try {
+        await _cameraController!.setFocusMode(FocusMode.auto);
+        await _cameraController!.setFocusPoint(const Offset(0.5, 0.5));
+      } catch (e) {
+        debugPrint('SCANNER: focus setup: $e');
+      }
 
       await _cameraController!.startImageStream(_onCameraFrame);
       setState(() => _cameraReady = true);
@@ -188,7 +236,16 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
   // ── Frame processing ──────────────────────────────────────────────────
 
+  int _frameCount = 0;
+
   void _onCameraFrame(CameraImage image) {
+    _frameCount++;
+    if (_frameCount == 1 || _frameCount % 100 == 0) {
+      debugPrint('SCANNER: frame #$_frameCount received '
+          '(${image.width}x${image.height}, format=${image.format.group}, '
+          'raw=${image.format.raw}, planes=${image.planes.length}, '
+          'sensor=${_camera?.sensorOrientation})');
+    }
     if (_isProcessing || _disposed) return;
     _isProcessing = true;
     _processFrame(image).whenComplete(() => _isProcessing = false);
@@ -196,11 +253,43 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
   Future<void> _processFrame(CameraImage image) async {
     try {
+      // Colour sampling — runs on raw bytes, sub-millisecond.
+      // Runs before ML Kit so colour updates even on frames where OCR is slow.
+      if (Platform.isIOS &&
+          image.planes.isNotEmpty &&
+          !_colourConfirmed) {
+        final sampled = ColourClassifier.sampleFromBgra8888(
+          bytes: image.planes[0].bytes,
+          width: image.width,
+          height: image.height,
+          bytesPerRow: image.planes[0].bytesPerRow,
+        );
+        final match = ColourClassifier.classify(sampled);
+        _colourStabiliser.push(match.name, match.reference);
+      }
+
       final inputImage = _buildInputImage(image);
-      if (inputImage == null) return;
+      if (inputImage == null) {
+        debugPrint('SCANNER: _buildInputImage returned null — frame skipped');
+        return;
+      }
 
       final recognizedText = await _textRecognizer.processImage(inputImage);
       if (_disposed || !mounted) return;
+
+      // Debug: log what ML Kit sees
+      if (recognizedText.blocks.isEmpty) {
+        if (_frameCount % 50 == 0) {
+          debugPrint('SCANNER: ML Kit returned 0 blocks (frame #$_frameCount)');
+        }
+      }
+      if (recognizedText.blocks.isNotEmpty) {
+        final texts = recognizedText.blocks
+            .expand((b) => b.lines)
+            .map((l) => l.text)
+            .join(' | ');
+        debugPrint('SCANNER: ML Kit found ${recognizedText.blocks.length} blocks: $texts');
+      }
 
       final detections = <TextDetection>[];
 
@@ -211,8 +300,45 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
           bool wasMatched = false;
 
-          // Try brand matching
-          if (_detectedBrand == null) {
+          // Log every text line ML Kit reads (throttled)
+          if (_frameCount % 30 == 0) {
+            final modelCheck = BrandMatcher.matchModelAnyBrand(text);
+            final brandCheck = BrandMatcher.matchBrandDetailed(text);
+            debugPrint('SCANNER: text="$text" '
+                'modelMatch=${modelCheck != null ? "${modelCheck.brand}/${modelCheck.model}" : "none"} '
+                'brandMatch=${brandCheck?.displayName ?? "none"}');
+          }
+
+          // Model-first detection: check if text matches a known model
+          // from ANY brand. This handles cases where the model name is
+          // visible but the brand name isn't (e.g., "moxi2 kiss" → Unitron).
+          if (_detectedModel == null && !wasMatched) {
+            final reverse = BrandMatcher.matchModelAnyBrand(text);
+            if (reverse != null) {
+              // Model found — also sets brand if not already detected
+              detections.add(TextDetection(
+                boundingBox: line.boundingBox,
+                label: 'MODEL: ${reverse.model}',
+                type: DetectionType.matched,
+              ));
+              _detectedModel = reverse.model;
+              HapticFeedback.mediumImpact();
+              _captureSnapshot('MODEL', reverse.model, line.boundingBox);
+              wasMatched = true;
+
+              if (_detectedBrand == null) {
+                // Infer brand from model
+                _detectedBrand = reverse.brand;
+                _brandConfidence = 'FROM MODEL';
+                HapticFeedback.mediumImpact();
+                _showCrossReference(reverse.brand);
+                // No separate snapshot for brand — the model capture covers it
+              }
+            }
+          }
+
+          // Try brand matching (only if model-first didn't already find it)
+          if (_detectedBrand == null && !wasMatched) {
             final result = BrandMatcher.matchBrandDetailed(text);
             if (result != null) {
               detections.add(TextDetection(
@@ -227,7 +353,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
               _captureSnapshot('MAKE', result.displayName, line.boundingBox);
               wasMatched = true;
             }
-          } else {
+          } else if (_detectedBrand != null && !wasMatched) {
             // Brand already found — still highlight it
             final result = BrandMatcher.matchBrand(text);
             if (result != null) {
@@ -240,7 +366,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
             }
           }
 
-          // Try model matching
+          // Try model matching against known brand (if brand found first)
           if (_detectedBrand != null && _detectedModel == null && !wasMatched) {
             final model = BrandMatcher.matchModel(text, _detectedBrand!);
             if (model != null) {
@@ -284,22 +410,62 @@ class _LiveScanScreenState extends State<LiveScanScreen>
         if (detections.any((d) => d.type == DetectionType.matched)) {
           _showHint = false;
         }
+        // Update colour — show immediately, confidence builds over frames
+        if (!_colourConfirmed) {
+          _detectedColour = _colourStabiliser.leadingColour;
+          _detectedColourRgb = _colourStabiliser.leadingRgb;
+          _colourConfidence = _colourStabiliser.confidence;
+
+          // Auto-confirm once stabiliser reaches consensus
+          if (_colourStabiliser.isStable && !_colourConfirmed) {
+            _colourConfirmed = true;
+            HapticFeedback.lightImpact();
+            _captures.add(CapturedFeature(
+              id: 'COLOUR_${DateTime.now().millisecondsSinceEpoch}',
+              label: _detectedColour!,
+              field: 'COLOUR',
+            )..state = CaptureState.done);
+
+            // Colour locked → auto-capture a full-res still for OCR.
+            // The live stream at 720x1280 can't read tiny hearing aid text,
+            // but a 12MP still can.
+            _autoCapturForOcr();
+          }
+        }
       });
-    } catch (_) {
-      // ML Kit can fail on corrupt frames — skip silently
+    } catch (e, st) {
+      debugPrint('SCANNER: _processFrame error: $e\n$st');
     }
   }
 
   InputImage? _buildInputImage(CameraImage image) {
-    if (_camera == null) return null;
+    if (_camera == null) {
+      debugPrint('SCANNER: _camera is null');
+      return null;
+    }
 
-    final rotation = InputImageRotationValue.fromRawValue(
-      _camera!.sensorOrientation,
-    );
-    if (rotation == null) return null;
+    final sensorOrientation = _camera!.sensorOrientation;
+    final rotation = InputImageRotationValue.fromRawValue(sensorOrientation);
+    if (rotation == null) {
+      debugPrint('SCANNER: rotation null for sensorOrientation=$sensorOrientation');
+      return null;
+    }
 
-    final format = InputImageFormatValue.fromRawValue(image.format.raw as int);
-    if (format == null) return null;
+    // On iOS, image.format.raw may not cast cleanly to int.
+    // BGRA8888 on iOS = format value 1111970369.
+    final int rawFormat;
+    try {
+      rawFormat = image.format.raw as int;
+    } catch (e) {
+      debugPrint('SCANNER: format.raw cast failed: ${image.format.raw} (${image.format.raw.runtimeType})');
+      return null;
+    }
+
+    final format = InputImageFormatValue.fromRawValue(rawFormat);
+    if (format == null) {
+      debugPrint('SCANNER: format null for rawFormat=$rawFormat (group=${image.format.group})');
+      return null;
+    }
 
     return InputImage.fromBytes(
       bytes: _concatenatePlanes(image),
@@ -456,6 +622,252 @@ class _LiveScanScreenState extends State<LiveScanScreen>
     });
   }
 
+  // ── Colour picker ────────────────────────────────────────────────────
+
+  void _showColourPicker() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xF0000000),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => Padding(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'CORRECT COLOUR',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: Color(0x99FFFFFF),
+                letterSpacing: 2.0,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: ColourClassifier.palette.map((entry) {
+                final isDetected = entry.name == _detectedColour;
+                return GestureDetector(
+                  onTap: () {
+                    Navigator.pop(context);
+                    _confirmColour(entry.name, entry.color);
+                  },
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        width: 48,
+                        height: 48,
+                        decoration: BoxDecoration(
+                          color: entry.color,
+                          borderRadius: BorderRadius.circular(6),
+                          border: Border.all(
+                            color: isDetected
+                                ? AppColors.success
+                                : const Color(0x33FFFFFF),
+                            width: isDetected ? 2 : 1,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        entry.name.toUpperCase(),
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 9,
+                          fontWeight:
+                              isDetected ? FontWeight.w700 : FontWeight.w500,
+                          color: isDetected
+                              ? AppColors.success
+                              : const Color(0x88FFFFFF),
+                          letterSpacing: 0.3,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Called when the user corrects the auto-detected colour via the picker.
+  void _confirmColour(String name, Color rgb) {
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _detectedColour = name;
+      _detectedColourRgb = rgb;
+      _colourConfirmed = true;
+    });
+
+    // Update existing colour capture label, or add one if somehow missing
+    final existing = _captures.where((c) => c.field == 'COLOUR').firstOrNull;
+    if (existing != null) {
+      existing.label = name;
+    } else {
+      _captures.add(CapturedFeature(
+        id: 'COLOUR_${DateTime.now().millisecondsSinceEpoch}',
+        label: name,
+        field: 'COLOUR',
+      )..state = CaptureState.done);
+    }
+  }
+
+  // ── Auto-capture: full-res OCR ───────────────────────────────────────
+
+  bool _ocrCaptureInProgress = false;
+
+  /// Take a full-resolution still and run both the neural net brand classifier
+  /// AND ML Kit OCR on it. Triggered when colour stabilises.
+  ///
+  /// Two parallel identification signals:
+  /// 1. EfficientNet-B0 → brand classification from visual appearance (~10ms)
+  /// 2. ML Kit OCR → brand/model from text on the device (if readable)
+  /// Neural net result is primary; OCR can override or add model info.
+  Future<void> _autoCapturForOcr() async {
+    if (_ocrCaptureInProgress || _cameraController == null) return;
+    _ocrCaptureInProgress = true;
+
+    debugPrint('SCANNER: auto-capture triggered — running neural net + OCR');
+
+    try {
+      // Brief pause to capture a sharp still
+      await _cameraController!.stopImageStream();
+      final xFile = await _cameraController!.takePicture();
+
+      // Resume stream immediately — don't block the live view
+      if (mounted && _cameraController != null) {
+        await _cameraController!.startImageStream(_onCameraFrame);
+      }
+
+      if (_disposed || !mounted) return;
+
+      // ── Signal 1: Neural net brand classification ────────────────────
+      // Runs on Neural Engine (iOS) or GPU (Android), ~10ms
+      if (_brandClassifier.isLoaded && _detectedBrand == null) {
+        try {
+          final prediction = await _brandClassifier.classifyFile(xFile.path);
+          debugPrint('SCANNER: neural net → ${prediction.brand} '
+              '(${(prediction.confidence * 100).toStringAsFixed(1)}%)');
+
+          // Log top 3 for debugging
+          for (final p in prediction.topN(3)) {
+            debugPrint('  ${p.brand}: ${(p.probability * 100).toStringAsFixed(1)}%');
+          }
+
+          if (prediction.confidence >= 0.4 && mounted) {
+            setState(() {
+              _detectedBrand = prediction.brand;
+              _brandConfidence =
+                  '${(prediction.confidence * 100).round()}% AI';
+            });
+            HapticFeedback.mediumImpact();
+            _showCrossReference(prediction.brand);
+          }
+        } catch (e) {
+          debugPrint('SCANNER: neural net error: $e');
+        }
+      }
+
+      // ── Signal 2: ML Kit OCR (text on the device) ───────────────────
+      final inputImage = InputImage.fromFilePath(xFile.path);
+      final recognizedText = await _textRecognizer.processImage(inputImage);
+
+      if (_disposed || !mounted) return;
+
+      debugPrint('SCANNER: full-res OCR found '
+          '${recognizedText.blocks.length} blocks');
+
+      for (final block in recognizedText.blocks) {
+        for (final line in block.lines) {
+          final text = line.text.trim();
+          if (text.isEmpty || text.length < 2) continue;
+
+          debugPrint('SCANNER: full-res text: "$text"');
+
+          // Model-first detection (can also override neural net brand)
+          if (_detectedModel == null) {
+            final reverse = BrandMatcher.matchModelAnyBrand(text);
+            if (reverse != null) {
+              debugPrint('SCANNER: OCR MODEL MATCH: '
+                  '${reverse.brand} / ${reverse.model}');
+              setState(() {
+                _detectedModel = reverse.model;
+                // OCR model match is very reliable — override neural net
+                // brand if different
+                if (_detectedBrand != reverse.brand) {
+                  debugPrint('SCANNER: OCR overriding neural net brand '
+                      '$_detectedBrand → ${reverse.brand}');
+                  _detectedBrand = reverse.brand;
+                  _brandConfidence = 'FROM MODEL';
+                }
+              });
+              HapticFeedback.mediumImpact();
+              _showCrossReference(_detectedBrand!);
+            }
+          }
+
+          // Brand matching from OCR (if neural net didn't find it)
+          if (_detectedBrand == null) {
+            final result = BrandMatcher.matchBrandDetailed(text);
+            if (result != null) {
+              debugPrint('SCANNER: OCR BRAND MATCH: ${result.displayName}');
+              setState(() {
+                _detectedBrand = result.displayName;
+                _brandConfidence = result.confidenceLabel;
+              });
+              HapticFeedback.mediumImpact();
+              _showCrossReference(result.displayName);
+            }
+          }
+
+          // Brand-specific model matching
+          if (_detectedBrand != null && _detectedModel == null) {
+            final model = BrandMatcher.matchModel(text, _detectedBrand!);
+            if (model != null) {
+              debugPrint('SCANNER: OCR MODEL MATCH '
+                  '(brand-specific): $model');
+              setState(() => _detectedModel = model);
+              HapticFeedback.mediumImpact();
+            }
+          }
+        }
+      }
+
+      // Upload the captured image in background
+      _uploadInBackground(CapturedFeature(
+        id: 'SCAN_${DateTime.now().millisecondsSinceEpoch}',
+        label: _detectedBrand ?? 'scan',
+        field: 'SCAN',
+      )..imagePath = xFile.path);
+
+      // Check completion
+      if (_detectedBrand != null && !_completionFired) {
+        // Brand alone is enough to show completion — model is a bonus
+        _completionFired = true;
+        _fireCompletion();
+      }
+    } catch (e) {
+      debugPrint('SCANNER: auto-capture error: $e');
+      // Resume stream if it failed
+      if (mounted && _cameraController != null) {
+        try {
+          await _cameraController!.startImageStream(_onCameraFrame);
+        } catch (_) {}
+      }
+    } finally {
+      _ocrCaptureInProgress = false;
+    }
+  }
+
   // ── Actions ───────────────────────────────────────────────────────────
 
   Future<void> _captureAndReview() async {
@@ -537,8 +949,8 @@ class _LiveScanScreenState extends State<LiveScanScreen>
             ),
 
             // Feature overlay (green + amber boxes + snap ripples)
-            if (_phase != _ScanPhase.booting &&
-                (_liveDetections.isNotEmpty || _snapEvents.isNotEmpty))
+            // Always show when scanning — the overlay IS the T2 experience
+            if (_phase != _ScanPhase.booting)
               Positioned.fill(
                 child: AnimatedBuilder(
                   animation: _pulseController,
@@ -595,6 +1007,11 @@ class _LiveScanScreenState extends State<LiveScanScreen>
                       showHint: _showHint,
                       onReview: _captureAndReview,
                       onFallback: _pickFromGallery,
+                      detectedColour: _detectedColour,
+                      detectedColourRgb: _detectedColourRgb,
+                      colourConfidence: _colourConfidence,
+                      colourConfirmed: _colourConfirmed,
+                      onColourTap: _showColourPicker,
                     ),
                     Container(
                       color: Colors.black,

--- a/recycled_sound/lib/features/scanner/presentation/live_scanner_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/live_scanner_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -20,6 +21,11 @@ import 'widgets/capture_stack.dart';
 import 'widgets/feature_overlay_painter.dart';
 import 'widgets/progress_rail.dart';
 import 'widgets/scan_hud.dart';
+
+/// Debug log for scanner — compiled out in release builds.
+void _log(String message) {
+  if (kDebugMode) debugPrint('SCANNER: $message');
+}
 
 /// The scanner's lifecycle phases.
 enum _ScanPhase { booting, scanning, complete }
@@ -113,7 +119,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
     // Pre-load model during boot sequence — catch errors so it doesn't
     // crash the app if the TFLite runtime is incompatible
     _brandClassifier.load().catchError((e) {
-      debugPrint('SCANNER: brand classifier failed to load: $e');
+      _log('brand classifier failed to load: $e');
     });
 
     _hintTimer = Timer(const Duration(seconds: 15), () {
@@ -178,7 +184,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
       // Log all available cameras to find the ultra-wide (macro-capable)
       for (final cam in cameras) {
-        debugPrint('SCANNER: camera: ${cam.name}, '
+        _log('camera: ${cam.name}, '
             'direction=${cam.lensDirection}, '
             'sensor=${cam.sensorOrientation}');
       }
@@ -189,14 +195,14 @@ class _LiveScanScreenState extends State<LiveScanScreen>
       final backCameras = cameras
           .where((c) => c.lensDirection == CameraLensDirection.back)
           .toList();
-      debugPrint('SCANNER: ${backCameras.length} back cameras found');
+      _log('${backCameras.length} back cameras found');
 
       // Use the main wide camera for live preview.
       // The neural net doesn't need macro focus — it identifies brands
       // from visual appearance at normal viewing distance.
       // cameras.first is the default back camera (main wide lens).
       _camera = cameras.first;
-      debugPrint('SCANNER: selected camera: ${_camera!.name}');
+      _log('selected camera: ${_camera!.name}');
       _cameraController = CameraController(
         _camera!,
         ResolutionPreset.high,
@@ -216,7 +222,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
         await _cameraController!.setFocusMode(FocusMode.auto);
         await _cameraController!.setFocusPoint(const Offset(0.5, 0.5));
       } catch (e) {
-        debugPrint('SCANNER: focus setup: $e');
+        _log('focus setup: $e');
       }
 
       await _cameraController!.startImageStream(_onCameraFrame);
@@ -241,7 +247,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
   void _onCameraFrame(CameraImage image) {
     _frameCount++;
     if (_frameCount == 1 || _frameCount % 100 == 0) {
-      debugPrint('SCANNER: frame #$_frameCount received '
+      _log('frame #$_frameCount received '
           '(${image.width}x${image.height}, format=${image.format.group}, '
           'raw=${image.format.raw}, planes=${image.planes.length}, '
           'sensor=${_camera?.sensorOrientation})');
@@ -270,7 +276,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
       final inputImage = _buildInputImage(image);
       if (inputImage == null) {
-        debugPrint('SCANNER: _buildInputImage returned null — frame skipped');
+        _log('_buildInputImage returned null — frame skipped');
         return;
       }
 
@@ -280,7 +286,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
       // Debug: log what ML Kit sees
       if (recognizedText.blocks.isEmpty) {
         if (_frameCount % 50 == 0) {
-          debugPrint('SCANNER: ML Kit returned 0 blocks (frame #$_frameCount)');
+          _log('ML Kit returned 0 blocks (frame #$_frameCount)');
         }
       }
       if (recognizedText.blocks.isNotEmpty) {
@@ -288,7 +294,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
             .expand((b) => b.lines)
             .map((l) => l.text)
             .join(' | ');
-        debugPrint('SCANNER: ML Kit found ${recognizedText.blocks.length} blocks: $texts');
+        _log('ML Kit found ${recognizedText.blocks.length} blocks: $texts');
       }
 
       final detections = <TextDetection>[];
@@ -304,7 +310,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
           if (_frameCount % 30 == 0) {
             final modelCheck = BrandMatcher.matchModelAnyBrand(text);
             final brandCheck = BrandMatcher.matchBrandDetailed(text);
-            debugPrint('SCANNER: text="$text" '
+            _log('text="$text" '
                 'modelMatch=${modelCheck != null ? "${modelCheck.brand}/${modelCheck.model}" : "none"} '
                 'brandMatch=${brandCheck?.displayName ?? "none"}');
           }
@@ -434,20 +440,20 @@ class _LiveScanScreenState extends State<LiveScanScreen>
         }
       });
     } catch (e, st) {
-      debugPrint('SCANNER: _processFrame error: $e\n$st');
+      _log('_processFrame error: $e\n$st');
     }
   }
 
   InputImage? _buildInputImage(CameraImage image) {
     if (_camera == null) {
-      debugPrint('SCANNER: _camera is null');
+      _log('_camera is null');
       return null;
     }
 
     final sensorOrientation = _camera!.sensorOrientation;
     final rotation = InputImageRotationValue.fromRawValue(sensorOrientation);
     if (rotation == null) {
-      debugPrint('SCANNER: rotation null for sensorOrientation=$sensorOrientation');
+      _log('rotation null for sensorOrientation=$sensorOrientation');
       return null;
     }
 
@@ -457,13 +463,13 @@ class _LiveScanScreenState extends State<LiveScanScreen>
     try {
       rawFormat = image.format.raw as int;
     } catch (e) {
-      debugPrint('SCANNER: format.raw cast failed: ${image.format.raw} (${image.format.raw.runtimeType})');
+      _log('format.raw cast failed: ${image.format.raw} (${image.format.raw.runtimeType})');
       return null;
     }
 
     final format = InputImageFormatValue.fromRawValue(rawFormat);
     if (format == null) {
-      debugPrint('SCANNER: format null for rawFormat=$rawFormat (group=${image.format.group})');
+      _log('format null for rawFormat=$rawFormat (group=${image.format.group})');
       return null;
     }
 
@@ -736,7 +742,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
     if (_ocrCaptureInProgress || _cameraController == null) return;
     _ocrCaptureInProgress = true;
 
-    debugPrint('SCANNER: auto-capture triggered — running neural net + OCR');
+    _log('auto-capture triggered — running neural net + OCR');
 
     try {
       // Brief pause to capture a sharp still
@@ -755,12 +761,12 @@ class _LiveScanScreenState extends State<LiveScanScreen>
       if (_brandClassifier.isLoaded && _detectedBrand == null) {
         try {
           final prediction = await _brandClassifier.classifyFile(xFile.path);
-          debugPrint('SCANNER: neural net → ${prediction.brand} '
+          _log('neural net → ${prediction.brand} '
               '(${(prediction.confidence * 100).toStringAsFixed(1)}%)');
 
           // Log top 3 for debugging
           for (final p in prediction.topN(3)) {
-            debugPrint('  ${p.brand}: ${(p.probability * 100).toStringAsFixed(1)}%');
+            _log('  ${p.brand}: ${(p.probability * 100).toStringAsFixed(1)}%');
           }
 
           if (prediction.confidence >= 0.4 && mounted) {
@@ -773,7 +779,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
             _showCrossReference(prediction.brand);
           }
         } catch (e) {
-          debugPrint('SCANNER: neural net error: $e');
+          _log('neural net error: $e');
         }
       }
 
@@ -783,7 +789,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
 
       if (_disposed || !mounted) return;
 
-      debugPrint('SCANNER: full-res OCR found '
+      _log('full-res OCR found '
           '${recognizedText.blocks.length} blocks');
 
       for (final block in recognizedText.blocks) {
@@ -791,20 +797,20 @@ class _LiveScanScreenState extends State<LiveScanScreen>
           final text = line.text.trim();
           if (text.isEmpty || text.length < 2) continue;
 
-          debugPrint('SCANNER: full-res text: "$text"');
+          _log('full-res text: "$text"');
 
           // Model-first detection (can also override neural net brand)
           if (_detectedModel == null) {
             final reverse = BrandMatcher.matchModelAnyBrand(text);
             if (reverse != null) {
-              debugPrint('SCANNER: OCR MODEL MATCH: '
+              _log('OCR MODEL MATCH: '
                   '${reverse.brand} / ${reverse.model}');
               setState(() {
                 _detectedModel = reverse.model;
                 // OCR model match is very reliable — override neural net
                 // brand if different
                 if (_detectedBrand != reverse.brand) {
-                  debugPrint('SCANNER: OCR overriding neural net brand '
+                  _log('OCR overriding neural net brand '
                       '$_detectedBrand → ${reverse.brand}');
                   _detectedBrand = reverse.brand;
                   _brandConfidence = 'FROM MODEL';
@@ -819,7 +825,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
           if (_detectedBrand == null) {
             final result = BrandMatcher.matchBrandDetailed(text);
             if (result != null) {
-              debugPrint('SCANNER: OCR BRAND MATCH: ${result.displayName}');
+              _log('OCR BRAND MATCH: ${result.displayName}');
               setState(() {
                 _detectedBrand = result.displayName;
                 _brandConfidence = result.confidenceLabel;
@@ -833,7 +839,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
           if (_detectedBrand != null && _detectedModel == null) {
             final model = BrandMatcher.matchModel(text, _detectedBrand!);
             if (model != null) {
-              debugPrint('SCANNER: OCR MODEL MATCH '
+              _log('OCR MODEL MATCH '
                   '(brand-specific): $model');
               setState(() => _detectedModel = model);
               HapticFeedback.mediumImpact();
@@ -856,7 +862,7 @@ class _LiveScanScreenState extends State<LiveScanScreen>
         _fireCompletion();
       }
     } catch (e) {
-      debugPrint('SCANNER: auto-capture error: $e');
+      _log('auto-capture error: $e');
       // Resume stream if it failed
       if (mounted && _cameraController != null) {
         try {

--- a/recycled_sound/lib/features/scanner/presentation/results_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/results_screen.dart
@@ -83,7 +83,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.brand,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('brand', v),
+                          .updateField(ScanField.brand, v),
                     ),
                     const Divider(),
                     _EditableSpecRow(
@@ -91,7 +91,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.model,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('model', v),
+                          .updateField(ScanField.model, v),
                     ),
                     const Divider(),
                     _EditableSpecRow(
@@ -99,7 +99,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.type,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('type', v),
+                          .updateField(ScanField.type, v),
                     ),
                     if (result.colour != null) ...[
                       const Divider(),
@@ -108,7 +108,7 @@ class ResultsScreen extends ConsumerWidget {
                         field: result.colour!,
                         onSave: (v) => ref
                             .read(scanResultProvider.notifier)
-                            .updateField('colour', v),
+                            .updateField(ScanField.colour, v),
                       ),
                     ],
                     const Divider(),
@@ -117,7 +117,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.year,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('year', v),
+                          .updateField(ScanField.year, v),
                     ),
                   ],
                 ),
@@ -136,7 +136,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.batterySize,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('batterySize', v),
+                          .updateField(ScanField.batterySize, v),
                     ),
                     const Divider(),
                     _EditableSpecRow(
@@ -144,7 +144,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.domeType,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('domeType', v),
+                          .updateField(ScanField.domeType, v),
                     ),
                     const Divider(),
                     _EditableSpecRow(
@@ -152,7 +152,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.waxFilter,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('waxFilter', v),
+                          .updateField(ScanField.waxFilter, v),
                     ),
                     const Divider(),
                     _EditableSpecRow(
@@ -160,7 +160,7 @@ class ResultsScreen extends ConsumerWidget {
                       field: result.receiver,
                       onSave: (v) => ref
                           .read(scanResultProvider.notifier)
-                          .updateField('receiver', v),
+                          .updateField(ScanField.receiver, v),
                     ),
                   ],
                 ),

--- a/recycled_sound/lib/features/scanner/presentation/results_screen.dart
+++ b/recycled_sound/lib/features/scanner/presentation/results_screen.dart
@@ -101,6 +101,16 @@ class ResultsScreen extends ConsumerWidget {
                           .read(scanResultProvider.notifier)
                           .updateField('type', v),
                     ),
+                    if (result.colour != null) ...[
+                      const Divider(),
+                      _EditableSpecRow(
+                        label: 'Colour',
+                        field: result.colour!,
+                        onSave: (v) => ref
+                            .read(scanResultProvider.notifier)
+                            .updateField('colour', v),
+                      ),
+                    ],
                     const Divider(),
                     _EditableSpecRow(
                       label: 'Year',

--- a/recycled_sound/lib/features/scanner/presentation/widgets/capture_stack.dart
+++ b/recycled_sound/lib/features/scanner/presentation/widgets/capture_stack.dart
@@ -18,8 +18,8 @@ class CapturedFeature {
 
   final String id;
 
-  /// Display label, e.g. "OTICON".
-  final String label;
+  /// Display label, e.g. "OTICON". Mutable to allow corrections.
+  String label;
 
   /// Which field this is: "MAKE", "MODEL", etc.
   final String field;

--- a/recycled_sound/lib/features/scanner/presentation/widgets/feature_overlay_painter.dart
+++ b/recycled_sound/lib/features/scanner/presentation/widgets/feature_overlay_painter.dart
@@ -76,6 +76,9 @@ class FeatureOverlayPainter extends CustomPainter {
       _drawSnapRipple(canvas, rect, age / 500.0);
     }
 
+    // Always draw a centre scanning reticle — the T2 "I'm looking" signal
+    _drawScanReticle(canvas, size);
+
     if (detections.isEmpty) return;
 
     // Draw ambient detections first (underneath)
@@ -97,24 +100,17 @@ class FeatureOverlayPainter extends CustomPainter {
   }
 
   Rect _transformRect(Rect rect, Size widgetSize) {
-    final Size rotatedSize;
-    if (sensorOrientation == 90 || sensorOrientation == 270) {
-      rotatedSize = Size(imageSize.height, imageSize.width);
-    } else {
-      rotatedSize = imageSize;
-    }
-
-    final scaleX = widgetSize.width / rotatedSize.width;
-    final scaleY = widgetSize.height / rotatedSize.height;
-    final scale = scaleX > scaleY ? scaleX : scaleY;
-    final offsetX = (widgetSize.width - rotatedSize.width * scale) / 2;
-    final offsetY = (widgetSize.height - rotatedSize.height * scale) / 2;
+    // On iOS, ML Kit returns bounding boxes already in display-oriented
+    // coordinates (it applies the InputImageRotation internally). So we only
+    // need to scale from image space to widget space — no rotation needed.
+    final scaleX = widgetSize.width / imageSize.width;
+    final scaleY = widgetSize.height / imageSize.height;
 
     return Rect.fromLTRB(
-      rect.left * scale + offsetX,
-      rect.top * scale + offsetY,
-      rect.right * scale + offsetX,
-      rect.bottom * scale + offsetY,
+      rect.left * scaleX,
+      rect.top * scaleY,
+      rect.right * scaleX,
+      rect.bottom * scaleY,
     );
   }
 
@@ -145,6 +141,31 @@ class FeatureOverlayPainter extends CustomPainter {
       ..strokeCap = StrokeCap.round;
 
     _drawCorners(canvas, rect.inflate(4), paint);
+  }
+
+  /// Centre-frame scanning reticle — always visible while scanning.
+  /// Pulses gently in amber to show the scanner is active and looking.
+  void _drawScanReticle(Canvas canvas, Size size) {
+    final cx = size.width / 2;
+    final cy = size.height / 2;
+    final side = size.shortestSide * 0.35;
+
+    // Visible breathing effect
+    final breath = 1.0 + 0.06 * animationValue;
+    final rect = Rect.fromCenter(
+      center: Offset(cx, cy),
+      width: side * breath,
+      height: side * breath,
+    );
+
+    final opacity = 0.2 + 0.4 * animationValue; // 0.2 → 0.6
+    final paint = Paint()
+      ..color = _ambientColor.withValues(alpha: opacity)
+      ..strokeWidth = 1.5 + 1.0 * animationValue // 1.5 → 2.5
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    _drawCorners(canvas, rect, paint);
   }
 
   void _drawAmbientBrackets(Canvas canvas, Rect rect) {
@@ -206,8 +227,5 @@ class FeatureOverlayPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant FeatureOverlayPainter old) =>
-      detections != old.detections ||
-      animationValue != old.animationValue ||
-      snapEvents.length != old.snapEvents.length;
+  bool shouldRepaint(covariant FeatureOverlayPainter old) => true;
 }

--- a/recycled_sound/lib/features/scanner/presentation/widgets/scan_hud.dart
+++ b/recycled_sound/lib/features/scanner/presentation/widgets/scan_hud.dart
@@ -18,6 +18,11 @@ class ScanHud extends StatelessWidget {
     required this.showHint,
     required this.onReview,
     required this.onFallback,
+    this.detectedColour,
+    this.detectedColourRgb,
+    this.colourConfidence = 0.0,
+    this.colourConfirmed = false,
+    this.onColourTap,
   });
 
   final String? detectedBrand;
@@ -33,7 +38,23 @@ class ScanHud extends StatelessWidget {
   final VoidCallback onReview;
   final VoidCallback onFallback;
 
-  bool get _hasDetections => detectedBrand != null || detectedModel != null;
+  /// Detected colour name from the stabiliser, e.g. "Champagne".
+  final String? detectedColour;
+
+  /// The palette reference colour for the swatch.
+  final Color? detectedColourRgb;
+
+  /// Colour detection confidence 0.0–1.0 (fills over ~8 frames).
+  final double colourConfidence;
+
+  /// Whether the colour has reached consensus or been manually confirmed.
+  final bool colourConfirmed;
+
+  /// Called when the user taps the colour row to open the picker.
+  final VoidCallback? onColourTap;
+
+  bool get _hasDetections =>
+      detectedBrand != null || detectedModel != null || detectedColour != null;
   bool get _isComplete => detectedBrand != null && detectedModel != null;
 
   @override
@@ -82,6 +103,16 @@ class ScanHud extends StatelessWidget {
               value: detectedModel,
               detected: detectedModel != null,
             ),
+            if (detectedColour != null) ...[
+              const SizedBox(height: 4),
+              _ColourRow(
+                colour: detectedColour!,
+                colourRgb: detectedColourRgb,
+                confidence: colourConfidence,
+                confirmed: colourConfirmed,
+                onTap: onColourTap,
+              ),
+            ],
             const SizedBox(height: 12),
           ],
 
@@ -222,6 +253,114 @@ class _FeatureRow extends StatelessWidget {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// Colour detection row with swatch and tap-to-confirm interaction.
+class _ColourRow extends StatelessWidget {
+  const _ColourRow({
+    required this.colour,
+    required this.colourRgb,
+    required this.confidence,
+    required this.confirmed,
+    this.onTap,
+  });
+
+  final String colour;
+  final Color? colourRgb;
+  final double confidence;
+  final bool confirmed;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: confirmed ? onTap : null, // Only tappable once confirmed (to correct)
+      child: Row(
+        children: [
+          // Status: filling circle while building confidence, checkmark when done
+          if (confirmed)
+            const Icon(Icons.check_circle, size: 16, color: AppColors.success)
+          else
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                value: confidence,
+                strokeWidth: 2,
+                color: AppColors.success,
+                backgroundColor: const Color(0x33FFFFFF),
+              ),
+            ),
+          const SizedBox(width: 8),
+          // Field label
+          const SizedBox(
+            width: 52,
+            child: Text(
+              'COLOUR',
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: Color(0x99FFFFFF),
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          // Colour swatch — opacity grows with confidence
+          if (colourRgb != null) ...[
+            Container(
+              width: 16,
+              height: 16,
+              decoration: BoxDecoration(
+                color: colourRgb!.withValues(alpha: 0.4 + 0.6 * confidence),
+                borderRadius: BorderRadius.circular(3),
+                border: Border.all(
+                  color: const Color(0x55FFFFFF),
+                  width: 1,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          // Colour name — opacity grows with confidence
+          Expanded(
+            child: Text(
+              colour,
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 13,
+                fontWeight: confirmed ? FontWeight.w600 : FontWeight.w400,
+                color: confirmed
+                    ? AppColors.success
+                    : AppColors.success.withValues(
+                        alpha: 0.3 + 0.7 * confidence),
+                letterSpacing: 0.3,
+              ),
+            ),
+          ),
+          // Edit badge — only after confirmed
+          if (confirmed)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(3),
+                color: const Color(0x33FFFFFF),
+              ),
+              child: const Text(
+                'EDIT',
+                style: TextStyle(
+                  fontFamily: 'monospace',
+                  fontSize: 9,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0x99FFFFFF),
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/recycled_sound/lib/features/scanner/providers/scanner_providers.dart
+++ b/recycled_sound/lib/features/scanner/providers/scanner_providers.dart
@@ -64,29 +64,13 @@ class ScanResultNotifier extends Notifier<ScanResult> {
   }
 
   /// Update a single spec field and record the correction with full context.
-  void updateField(String fieldName, String newValue) {
+  ///
+  /// Takes a [ScanField] enum — the compiler enforces exhaustive handling,
+  /// so adding a field to [ScanResult] without updating the read/write
+  /// switches is a compile error, not a silent bug.
+  void updateField(ScanField field, String newValue) {
     final current = state;
-    // Known field names — reject anything not in this set.
-    const knownFields = {
-      'brand', 'model', 'type', 'year', 'batterySize',
-      'domeType', 'waxFilter', 'receiver', 'colour', 'tubing', 'powerSource',
-    };
-    if (!knownFields.contains(fieldName)) return;
-
-    final oldField = switch (fieldName) {
-      'brand' => current.brand,
-      'model' => current.model,
-      'type' => current.type,
-      'year' => current.year,
-      'batterySize' => current.batterySize,
-      'domeType' => current.domeType,
-      'waxFilter' => current.waxFilter,
-      'receiver' => current.receiver,
-      'colour' => current.colour,
-      'tubing' => current.tubing,
-      'powerSource' => current.powerSource,
-      _ => null, // unreachable after guard above
-    };
+    final oldField = current.fieldFor(field);
 
     // For fields that start null (tubing, powerSource, colour),
     // record the correction from empty.
@@ -95,7 +79,7 @@ class ScanResultNotifier extends Notifier<ScanResult> {
     if (originalValue == newValue) return;
 
     _corrections.add(Correction(
-      field: fieldName,
+      field: field.name,
       originalValue: originalValue,
       originalConfidence: originalConfidence,
       correctedValue: newValue,
@@ -105,20 +89,7 @@ class ScanResultNotifier extends Notifier<ScanResult> {
 
     // Update the field with 100% confidence (human-corrected).
     final corrected = SpecField(value: newValue, confidence: 100);
-    state = switch (fieldName) {
-      'brand' => current.copyWith(brand: corrected),
-      'model' => current.copyWith(model: corrected),
-      'type' => current.copyWith(type: corrected),
-      'year' => current.copyWith(year: corrected),
-      'batterySize' => current.copyWith(batterySize: corrected),
-      'domeType' => current.copyWith(domeType: corrected),
-      'waxFilter' => current.copyWith(waxFilter: corrected),
-      'receiver' => current.copyWith(receiver: corrected),
-      'colour' => current.copyWith(colour: corrected),
-      'tubing' => current.copyWith(tubing: corrected),
-      'powerSource' => current.copyWith(powerSource: corrected),
-      _ => current,
-    };
+    state = current.withField(field, corrected);
   }
 
   /// Returns all corrections made during this session.

--- a/recycled_sound/lib/features/scanner/providers/scanner_providers.dart
+++ b/recycled_sound/lib/features/scanner/providers/scanner_providers.dart
@@ -66,6 +66,13 @@ class ScanResultNotifier extends Notifier<ScanResult> {
   /// Update a single spec field and record the correction with full context.
   void updateField(String fieldName, String newValue) {
     final current = state;
+    // Known field names — reject anything not in this set.
+    const knownFields = {
+      'brand', 'model', 'type', 'year', 'batterySize',
+      'domeType', 'waxFilter', 'receiver', 'colour', 'tubing', 'powerSource',
+    };
+    if (!knownFields.contains(fieldName)) return;
+
     final oldField = switch (fieldName) {
       'brand' => current.brand,
       'model' => current.model,
@@ -75,15 +82,22 @@ class ScanResultNotifier extends Notifier<ScanResult> {
       'domeType' => current.domeType,
       'waxFilter' => current.waxFilter,
       'receiver' => current.receiver,
-      _ => null,
+      'colour' => current.colour,
+      'tubing' => current.tubing,
+      'powerSource' => current.powerSource,
+      _ => null, // unreachable after guard above
     };
 
-    if (oldField == null || oldField.value == newValue) return;
+    // For fields that start null (tubing, powerSource, colour),
+    // record the correction from empty.
+    final originalValue = oldField?.value ?? '';
+    final originalConfidence = oldField?.confidence ?? 0;
+    if (originalValue == newValue) return;
 
     _corrections.add(Correction(
       field: fieldName,
-      originalValue: oldField.value,
-      originalConfidence: oldField.confidence,
+      originalValue: originalValue,
+      originalConfidence: originalConfidence,
       correctedValue: newValue,
       rawLabels: current.rawLabels,
       timestamp: DateTime.now(),
@@ -100,6 +114,9 @@ class ScanResultNotifier extends Notifier<ScanResult> {
       'domeType' => current.copyWith(domeType: corrected),
       'waxFilter' => current.copyWith(waxFilter: corrected),
       'receiver' => current.copyWith(receiver: corrected),
+      'colour' => current.copyWith(colour: corrected),
+      'tubing' => current.copyWith(tubing: corrected),
+      'powerSource' => current.copyWith(powerSource: corrected),
       _ => current,
     };
   }

--- a/recycled_sound/pubspec.lock
+++ b/recycled_sound/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -592,6 +600,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: "direct main"
+    description:
+      name: image
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -840,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -864,6 +888,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -880,6 +912,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   riverpod:
     dependency: transitive
     description:
@@ -1013,6 +1053,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  tflite_flutter:
+    dependency: "direct main"
+    description:
+      name: tflite_flutter
+      sha256: "48e6fde2ad97162bb66a16a142f4c4698add9e8cd397ce9d1cc7451b55537ac1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   timing:
     dependency: transitive
     description:
@@ -1093,6 +1141,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/recycled_sound/pubspec.yaml
+++ b/recycled_sound/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   camera: ^0.11.1
   image_picker: ^1.1.2
   google_mlkit_text_recognition: ^0.15.1
+  tflite_flutter: ^0.11.0
+  image: ^4.5.3
 
 dev_dependencies:
   flutter_test:
@@ -39,3 +41,5 @@ flutter:
   assets:
     - assets/device_db.bin
     - assets/device_catalog.json
+    - assets/brand_classifier.tflite
+    - assets/brand_classifier_labels.json

--- a/recycled_sound/test/embedding_search_test.dart
+++ b/recycled_sound/test/embedding_search_test.dart
@@ -7,9 +7,7 @@ void main() {
   group('EmbeddingSearch', () {
     test('findSimilar returns correct rankings for known vectors', () {
       // Create a small test database with 3 embeddings of 4 dims
-      final search = EmbeddingSearch.instance;
-
-      // We can't easily test loadFromAsset without Flutter's asset bundle,
+      // EmbeddingSearch.instance exists but needs Flutter's asset bundle,
       // but we can verify the similarity math with a direct test.
       // This test validates the cosine similarity algorithm.
 

--- a/recycled_sound/test/scanner_providers_test.dart
+++ b/recycled_sound/test/scanner_providers_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:recycled_sound/features/scanner/data/models/scan_result.dart';
 import 'package:recycled_sound/features/scanner/providers/scanner_providers.dart';
 
+// ScanField enum is exported from scan_result.dart
+
 void main() {
   group('ScanResultNotifier', () {
     late ProviderContainer container;
@@ -25,7 +27,7 @@ void main() {
 
     test('updateField changes value and sets confidence to 100', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('brand', 'Oticon');
+      notifier.updateField(ScanField.brand, 'Oticon');
 
       final result = container.read(scanResultProvider);
       expect(result.brand.value, 'Oticon');
@@ -34,7 +36,7 @@ void main() {
 
     test('updateField records correction', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('model', 'Real 1');
+      notifier.updateField(ScanField.model, 'Real 1');
 
       final corrections = notifier.corrections;
       expect(corrections, hasLength(1));
@@ -46,24 +48,20 @@ void main() {
 
     test('updateField with same value does nothing', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('brand', 'Phonak'); // same as mock
+      notifier.updateField(ScanField.brand, 'Phonak'); // same as mock
 
       expect(notifier.corrections, isEmpty);
       expect(container.read(scanResultProvider).brand.value, 'Phonak');
     });
 
-    test('updateField with invalid field does nothing', () {
-      final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('nonexistent', 'value');
-
-      expect(notifier.corrections, isEmpty);
-    });
+    // Note: the old "invalid field does nothing" test is no longer needed —
+    // ScanField is an enum, so the compiler prevents invalid field names.
 
     test('multiple corrections are tracked in order', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('brand', 'Signia');
-      notifier.updateField('type', 'BTE');
-      notifier.updateField('batterySize', '13');
+      notifier.updateField(ScanField.brand, 'Signia');
+      notifier.updateField(ScanField.type, 'BTE');
+      notifier.updateField(ScanField.batterySize, '13');
 
       final corrections = notifier.corrections;
       expect(corrections, hasLength(3));
@@ -74,7 +72,7 @@ void main() {
 
     test('corrections include raw labels from scan', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('brand', 'Widex');
+      notifier.updateField(ScanField.brand, 'Widex');
 
       final correction = notifier.corrections.first;
       expect(correction.rawLabels, isNotEmpty);
@@ -84,7 +82,7 @@ void main() {
 
     test('correction toJson produces valid map', () {
       final notifier = container.read(scanResultProvider.notifier);
-      notifier.updateField('year', '2023');
+      notifier.updateField(ScanField.year, '2023');
 
       final json = notifier.corrections.first.toJson();
       expect(json['field'], 'year');


### PR DESCRIPTION
## Summary

- **On-device colour detection** — samples dominant colour from camera frames using CIELAB perceptual distance, classifies against a 10-colour hearing aid palette, stabilises with voting buffer. Addresses field 7 of Seray's 7-field identification model.
- **On-device brand classifier** — EfficientNet-B0 fine-tuned on 1,505 hearing aid images across 10 brands. 91.3% validation accuracy. Runs on Neural Engine via TFLite (~10ms inference on iPhone 14 Pro). No cloud call needed.
- **Auto-capture pipeline** — colour lock triggers still capture automatically (no button press). Neural net identifies brand from visual appearance, OCR runs in parallel for model text. Two signals fused on-device.
- **Scanning reticle** — pulsing amber corner brackets always visible while scanning. T2 aesthetic maintained.
- **Model-first OCR** — reverse-lookup lets model text (e.g., "moxi") infer brand (Unitron), even when brand name isn't visible on the device.

## Architecture

```
Live stream (30fps)
├── Colour sampling (BGRA8888, <0.1ms) → builds confidence → locks
│   └── Triggers auto-capture
└── Ambient text detection (ML Kit, low-res)

Still capture (12MP)
├── EfficientNet-B0 (Neural Engine, ~10ms) → brand + confidence
└── ML Kit OCR (full-res) → brand/model from text
    └── Can override neural net if model text implies different brand
```

## Training

- 2,170 images downloaded from unaudinary.com
- Brand aliases merged (Hansaton→Signia, Rexton→Signia, Jabra→ReSound)
- White-labels dropped (Specsavers, Hearing Australia, Amplifon)
- Two-phase: frozen backbone (20 epochs) + fine-tune top 30 layers (10 epochs)
- Aggressive augmentation for domain gap (rotation, zoom, brightness, contrast)
- Float16 quantized TFLite: 8.5MB, 91.3% accuracy

## Test plan

- [ ] Scanner opens, amber reticle pulses in centre
- [ ] Point at coloured object → COLOUR row appears on HUD with confidence filling
- [ ] Colour locks → auto-capture fires (check console for "auto-capture triggered")
- [ ] Neural net returns brand prediction (check console for "neural net → Brand (XX%)")
- [ ] HUD shows detected brand with AI confidence badge
- [ ] Tap colour row → correction picker opens with T2-styled palette grid
- [ ] Results screen shows colour field

🤖 Generated with [Claude Code](https://claude.com/claude-code)